### PR TITLE
use new cancel apis everywhere attempt2

### DIFF
--- a/configure
+++ b/configure
@@ -15858,7 +15858,7 @@ fi
 LIBS_including_readline="$LIBS"
 LIBS=`echo "$LIBS" | sed -e 's/-ledit//g' -e 's/-lreadline//g'`
 
-for ac_func in backtrace_symbols copyfile copy_file_range elf_aux_info explicit_memset getauxval getifaddrs getpeerucred inet_pton kqueue localeconv_l mbstowcs_l memset_explicit posix_fallocate ppoll pthread_is_threaded_np setproctitle setproctitle_fast strsignal syncfs sync_file_range uselocale wcstombs_l
+for ac_func in backtrace_symbols copyfile copy_file_range elf_aux_info explicit_memset getauxval getifaddrs getpeerucred inet_pton kqueue localeconv_l mbstowcs_l memset_explicit posix_fallocate ppoll pselect pthread_is_threaded_np setproctitle setproctitle_fast strsignal syncfs sync_file_range uselocale wcstombs_l
 do :
   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
 ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"

--- a/configure.ac
+++ b/configure.ac
@@ -1961,6 +1961,7 @@ if test "$PORTNAME" = "win32"; then
   AC_LIBOBJ(dirmod)
   AC_LIBOBJ(kill)
   AC_LIBOBJ(open)
+  AC_LIBOBJ(pthread-win32)
   AC_LIBOBJ(system)
   AC_LIBOBJ(win32common)
   AC_LIBOBJ(win32dlopen)

--- a/configure.ac
+++ b/configure.ac
@@ -1864,6 +1864,7 @@ AC_CHECK_FUNCS(m4_normalize([
 	memset_explicit
 	posix_fallocate
 	ppoll
+	pselect
 	pthread_is_threaded_np
 	setproctitle
 	setproctitle_fast

--- a/meson.build
+++ b/meson.build
@@ -3215,6 +3215,7 @@ func_checks = [
   ['posix_fadvise'],
   ['posix_fallocate'],
   ['ppoll'],
+  ['pselect'],
   ['pthread_barrier_wait', {'dependencies': [thread_dep]}],
   ['pthread_is_threaded_np', {'dependencies': [thread_dep]}],
   ['sem_init', {'dependencies': [rt_dep, thread_dep], 'skip': sema_kind != 'unnamed_posix', 'define': false}],

--- a/meson.build
+++ b/meson.build
@@ -3642,7 +3642,7 @@ frontend_code = declare_dependency(
   include_directories: [postgres_inc],
   link_with: [fe_utils, common_static, pgport_static],
   sources: generated_headers_stamp,
-  dependencies: [os_deps, libintl],
+  dependencies: [os_deps, libintl, thread_dep],
 )
 
 backend_both_deps += [

--- a/src/bin/pg_amcheck/pg_amcheck.c
+++ b/src/bin/pg_amcheck/pg_amcheck.c
@@ -477,7 +477,7 @@ main(int argc, char *argv[])
 	cparams.dbname = NULL;
 	cparams.override_dbname = NULL;
 
-	setup_cancel_handler(NULL);
+	setup_cancel_handler(NULL, NULL);
 
 	/* choose the database for our initial connection */
 	if (opts.alldb)

--- a/src/bin/pg_dump/Makefile
+++ b/src/bin/pg_dump/Makefile
@@ -21,7 +21,7 @@ export LZ4
 export ZSTD
 export with_icu
 
-override CPPFLAGS := -I$(libpq_srcdir) $(CPPFLAGS)
+override CPPFLAGS := -I$(libpq_srcdir) -I$(top_srcdir)/src/port $(CPPFLAGS)
 LDFLAGS_INTERNAL += -L$(top_builddir)/src/fe_utils -lpgfeutils $(libpq_pgport)
 
 OBJS = \

--- a/src/bin/pg_dump/meson.build
+++ b/src/bin/pg_dump/meson.build
@@ -22,6 +22,8 @@ pg_dump_common_sources = files(
 pg_dump_common = static_library('libpgdump_common',
   pg_dump_common_sources,
   c_pch: pch_postgres_fe_h,
+  # port needs to be in include path due to pthread-win32.h
+  include_directories: ['../../port'],
   dependencies: [frontend_code, libpq, lz4, zlib, zstd],
   kwargs: internal_lib_args,
 )

--- a/src/bin/pg_dump/parallel.c
+++ b/src/bin/pg_dump/parallel.c
@@ -60,6 +60,8 @@
 #include <fcntl.h>
 #endif
 
+#include "common/logging.h"
+#include "fe_utils/cancel.h"
 #include "fe_utils/string_utils.h"
 #include "parallel.h"
 #include "pg_backup_utils.h"
@@ -174,10 +176,6 @@ typedef struct DumpSignalInformation
 
 static volatile DumpSignalInformation signal_info;
 
-#ifdef WIN32
-static CRITICAL_SECTION signal_info_lock;
-#endif
-
 /*
  * Write a simple string to stderr --- must be safe in a signal handler.
  * We ignore the write() result since there's not much we could do about it.
@@ -209,6 +207,7 @@ static void WaitForTerminatingWorkers(ParallelState *pstate);
 static void set_cancel_handler(void);
 static void set_cancel_pstate(ParallelState *pstate);
 static void set_cancel_slot_archive(ParallelSlot *slot, ArchiveHandle *AH);
+static void StopWorkers(void);
 static void RunWorker(ArchiveHandle *AH, ParallelSlot *slot);
 static int	GetIdleWorker(ParallelState *pstate);
 static bool HasEveryWorkerTerminated(ParallelState *pstate);
@@ -410,32 +409,9 @@ ShutdownWorkersHard(ParallelState *pstate)
 	/*
 	 * Force early termination of any commands currently in progress.
 	 */
-#ifndef WIN32
-	/* On non-Windows, send SIGTERM to each worker process. */
-	for (i = 0; i < pstate->numWorkers; i++)
-	{
-		pid_t		pid = pstate->parallelSlot[i].pid;
-
-		if (pid != 0)
-			kill(pid, SIGTERM);
-	}
-#else
-
-	/*
-	 * On Windows, send query cancels directly to the workers' backends.  Use
-	 * a critical section to ensure worker threads don't change state.
-	 */
-	EnterCriticalSection(&signal_info_lock);
-	for (i = 0; i < pstate->numWorkers; i++)
-	{
-		ArchiveHandle *AH = pstate->parallelSlot[i].AH;
-		char		errbuf[1];
-
-		if (AH != NULL && AH->connCancel != NULL)
-			(void) PQcancel(AH->connCancel, errbuf, sizeof(errbuf));
-	}
-	LeaveCriticalSection(&signal_info_lock);
-#endif
+	LockCancelThread();
+	StopWorkers();
+	UnlockCancelThread();
 
 	/* Now wait for them to terminate. */
 	WaitForTerminatingWorkers(pstate);
@@ -519,75 +495,68 @@ WaitForTerminatingWorkers(ParallelState *pstate)
  * could leave a SQL command (e.g., CREATE INDEX on a large table) running
  * for a long time.  Instead, we try to send a cancel request and then die.
  * pg_dump probably doesn't really need this, but we might as well use it
- * there too.  Note that sending the cancel directly from the signal handler
- * is safe because PQcancel() is written to make it so.
+ * there too.
  *
- * In parallel operation on Unix, each process is responsible for canceling
- * its own connection (this must be so because nobody else has access to it).
- * Furthermore, the leader process should attempt to forward its signal to
- * each child.  In simple manual use of pg_dump/pg_restore, forwarding isn't
- * needed because typing control-C at the console would deliver SIGINT to
- * every member of the terminal process group --- but in other scenarios it
- * might be that only the leader gets signaled.
+ * On Unix, the signal handler wakes up a dedicated cancel thread via a
+ * self-pipe, which then sends the cancel and calls _exit().  This thread also
+ * forwards the signal to each child so they can also cancel their queries. In
+ * simple manual use of pg_dump/pg_restore, forwarding isn't needed because
+ * typing control-C at the console would deliver SIGINT to every member of the
+ * terminal process group --- but in other scenarios it might be that only the
+ * leader gets signaled.
  *
  * On Windows, the cancel handler runs in a separate thread, because that's
  * how SetConsoleCtrlHandler works.  Because the workers are threads in this
  * same process, we set a flag (is_cancel_in_progress()) so they stay quiet
  * about the query cancellations instead of cluttering the screen, then send
- * cancels on all active connections and return FALSE, which will allow the
- * process to die.  For safety's sake, we use a critical section to protect
- * the PGcancel structures against being changed while the signal thread runs.
+ * cancels on all active connections and call _exit() to terminate the
+ * process.  Access to the shared PGcancelConn structures is serialized against
+ * the main thread by the cancel thread lock held around the callback.
  */
-
-#ifndef WIN32
 
 /*
- * Signal handler (Unix only)
+ * Cancel all active queries, print a termination message, and exit.
+ *
+ * Invoked from the cancel thread (Unix) or the Windows console handler thread.
+ * It never returns: after sending the cancels it calls _exit() so that the
+ * process terminates on cancel.  We use _exit() rather than exit() because the
+ * latter would invoke atexit handlers that can fail if we interrupted related
+ * code.
  */
-static void
-sigTermHandler(SIGNAL_ARGS)
+pg_noreturn static void
+CancelBackendsAndExit(void)
 {
-	int			i;
-	char		errbuf[1];
+#ifdef WIN32
 
 	/*
-	 * Some platforms allow delivery of new signals to interrupt an active
-	 * signal handler.  That could muck up our attempt to send PQcancel, so
-	 * disable the signals that set_cancel_handler enabled.
+	 * On Windows the workers are threads within this same process.  Once we
+	 * cancel their queries below they would receive the cancellation as an
+	 * error and report it, cluttering the user's screen in the brief window
+	 * before the process exits.  Tell them to stay quiet about it by setting
+	 * a flag.  This must be set before we send any cancel, so that a worker is
+	 * guaranteed to see it by the time its query fails as a result.
 	 */
-	pqsignal(SIGINT, PG_SIG_IGN);
-	pqsignal(SIGTERM, PG_SIG_IGN);
-	pqsignal(SIGQUIT, PG_SIG_IGN);
+	set_cancel_in_progress();
+#endif
 
 	/*
-	 * If we're in the leader, forward signal to all workers.  (It seems best
-	 * to do this before PQcancel; killing the leader transaction will result
-	 * in invalid-snapshot errors from active workers, which maybe we can
-	 * quiet by killing workers first.)  Ignore any errors.
+	 * Stop workers first to avoid invalid-snapshot errors if the leader
+	 * cancels before workers.
 	 */
-	if (signal_info.pstate != NULL)
-	{
-		for (i = 0; i < signal_info.pstate->numWorkers; i++)
-		{
-			pid_t		pid = signal_info.pstate->parallelSlot[i].pid;
+	StopWorkers();
 
-			if (pid != 0)
-				kill(pid, SIGTERM);
-		}
-	}
+	if (signal_info.myAH != NULL && signal_info.myAH->cancelConn != NULL)
+		(void) PQcancelBlocking(signal_info.myAH->cancelConn);
 
 	/*
-	 * Send QueryCancel if we have a connection to send to.  Ignore errors,
-	 * there's not much we can do about them anyway.
+	 * Print termination message. In parallel operation, only the leader
+	 * should print this. On Windows, workers are threads in the same process
+	 * and the console handler only runs in the leader context, so we can
+	 * always print it.
 	 */
-	if (signal_info.myAH != NULL && signal_info.myAH->connCancel != NULL)
-		(void) PQcancel(signal_info.myAH->connCancel, errbuf, sizeof(errbuf));
-
-	/*
-	 * Report we're quitting, using nothing more complicated than write(2).
-	 * When in parallel operation, only the leader process should do this.
-	 */
+#ifndef WIN32
 	if (!signal_info.am_worker)
+#endif
 	{
 		if (progname)
 		{
@@ -597,106 +566,42 @@ sigTermHandler(SIGNAL_ARGS)
 		write_stderr("terminated by user\n");
 	}
 
-	/*
-	 * And die, using _exit() not exit() because the latter will invoke atexit
-	 * handlers that can fail if we interrupted related code.
-	 */
 	_exit(1);
 }
 
 /*
- * Enable cancel interrupt handler, if not already done.
+ * Stop all worker processes/threads.
+ *
+ * On Unix, send SIGTERM to each worker process; their signal handlers will
+ * send cancel requests to their backends.
+ *
+ * On Windows, workers are threads in the same process, so we send cancel
+ * requests directly to their backends.
+ *
+ * Caller must hold the cancel thread lock (via LockCancelThread).
  */
 static void
-set_cancel_handler(void)
-{
-	/*
-	 * When forking, signal_info.handler_set will propagate into the new
-	 * process, but that's fine because the signal handler state does too.
-	 */
-	if (!signal_info.handler_set)
-	{
-		signal_info.handler_set = true;
-
-		pqsignal(SIGINT, sigTermHandler);
-		pqsignal(SIGTERM, sigTermHandler);
-		pqsignal(SIGQUIT, sigTermHandler);
-	}
-}
-
-#else							/* WIN32 */
-
-/*
- * Console interrupt handler --- runs in a newly-started thread.
- *
- * After stopping other threads and sending cancel requests on all open
- * connections, we return FALSE which will allow the default ExitProcess()
- * action to be taken.
- */
-static BOOL WINAPI
-consoleHandler(DWORD dwCtrlType)
+StopWorkers(void)
 {
 	int			i;
-	char		errbuf[1];
 
-	if (dwCtrlType == CTRL_C_EVENT ||
-		dwCtrlType == CTRL_BREAK_EVENT)
+	if (signal_info.pstate == NULL)
+		return;
+
+	for (i = 0; i < signal_info.pstate->numWorkers; i++)
 	{
-		/*
-		 * Tell worker threads to stay quiet about the query cancellations
-		 * we're about to send them; otherwise they'd report them as errors
-		 * and clutter the user's screen.  This must be set before we send any
-		 * cancel, so that a worker is guaranteed to see it by the time its
-		 * query fails as a result.
-		 */
-		set_cancel_in_progress();
+#ifndef WIN32
+		pid_t		pid = signal_info.pstate->parallelSlot[i].pid;
 
-		/* Critical section prevents changing data we look at here */
-		EnterCriticalSection(&signal_info_lock);
+		if (pid != 0)
+			kill(pid, SIGTERM);
+#else
+		ArchiveHandle *AH = signal_info.pstate->parallelSlot[i].AH;
 
-		/*
-		 * If in parallel mode, send QueryCancel to each worker's connected
-		 * backend.  Do this before canceling the main transaction, else we
-		 * might get invalid-snapshot errors reported before we can stop the
-		 * workers.  Ignore errors, there's not much we can do about them
-		 * anyway.
-		 */
-		if (signal_info.pstate != NULL)
-		{
-			for (i = 0; i < signal_info.pstate->numWorkers; i++)
-			{
-				ArchiveHandle *AH = signal_info.pstate->parallelSlot[i].AH;
-
-				if (AH != NULL && AH->connCancel != NULL)
-					(void) PQcancel(AH->connCancel, errbuf, sizeof(errbuf));
-			}
-		}
-
-		/*
-		 * Send QueryCancel to leader connection, if enabled.  Ignore errors,
-		 * there's not much we can do about them anyway.
-		 */
-		if (signal_info.myAH != NULL && signal_info.myAH->connCancel != NULL)
-			(void) PQcancel(signal_info.myAH->connCancel,
-							errbuf, sizeof(errbuf));
-
-		LeaveCriticalSection(&signal_info_lock);
-
-		/*
-		 * Report we're quitting, using nothing more complicated than
-		 * write(2).  We should be able to use pg_log_*() here, but for now we
-		 * stay aligned with the sigTermHandler behavior.
-		 */
-		if (progname)
-		{
-			write_stderr(progname);
-			write_stderr(": ");
-		}
-		write_stderr("terminated by user\n");
+		if (AH != NULL && AH->cancelConn != NULL)
+			(void) PQcancelBlocking(AH->cancelConn);
+#endif
 	}
-
-	/* Always return FALSE to allow signal handling to continue */
-	return FALSE;
 }
 
 /*
@@ -705,58 +610,55 @@ consoleHandler(DWORD dwCtrlType)
 static void
 set_cancel_handler(void)
 {
-	if (!signal_info.handler_set)
-	{
-		signal_info.handler_set = true;
+	if (signal_info.handler_set)
+		return;
 
-		InitializeCriticalSection(&signal_info_lock);
+	signal_info.handler_set = true;
 
-		SetConsoleCtrlHandler(consoleHandler, TRUE);
-	}
+	setup_cancel_handler(NULL, CancelBackendsAndExit);
+
+#ifndef WIN32
+	pqsignal(SIGTERM, CancelSignalHandler);
+	pqsignal(SIGQUIT, CancelSignalHandler);
+#endif
 }
-
-#endif							/* WIN32 */
 
 
 /*
  * set_archive_cancel_info
  *
- * Fill AH->connCancel with cancellation info for the specified database
+ * Fill AH->cancelConn with cancellation info for the specified database
  * connection; or clear it if conn is NULL.
  */
 void
 set_archive_cancel_info(ArchiveHandle *AH, PGconn *conn)
 {
-	PGcancel   *oldConnCancel;
+	PGcancelConn *oldCancelConn;
 
 	/*
-	 * Activate the interrupt handler if we didn't yet in this process.  On
-	 * Windows, this also initializes signal_info_lock; therefore it's
+	 * Activate the interrupt handler if we didn't yet in this process. It's
 	 * important that this happen at least once before we fork off any
 	 * threads.
 	 */
 	set_cancel_handler();
 
 	/*
-	 * On Unix, we assume that storing a pointer value is atomic with respect
-	 * to any possible signal interrupt.  On Windows, use a critical section.
+	 * Use mutex to prevent the cancel handler from using the pointer while
+	 * we're changing it.
 	 */
-
-#ifdef WIN32
-	EnterCriticalSection(&signal_info_lock);
-#endif
+	LockCancelThread();
 
 	/* Free the old one if we have one */
-	oldConnCancel = AH->connCancel;
+	oldCancelConn = AH->cancelConn;
 	/* be sure interrupt handler doesn't use pointer while freeing */
-	AH->connCancel = NULL;
+	AH->cancelConn = NULL;
 
-	if (oldConnCancel != NULL)
-		PQfreeCancel(oldConnCancel);
+	if (oldCancelConn != NULL)
+		PQcancelFinish(oldCancelConn);
 
 	/* Set the new one if specified */
 	if (conn)
-		AH->connCancel = PQgetCancel(conn);
+		AH->cancelConn = PQcancelCreate(conn);
 
 	/*
 	 * On Unix, there's only ever one active ArchiveHandle per process, so we
@@ -772,49 +674,35 @@ set_archive_cancel_info(ArchiveHandle *AH, PGconn *conn)
 		signal_info.myAH = AH;
 #endif
 
-#ifdef WIN32
-	LeaveCriticalSection(&signal_info_lock);
-#endif
+	UnlockCancelThread();
 }
 
 /*
  * set_cancel_pstate
  *
  * Set signal_info.pstate to point to the specified ParallelState, if any.
- * We need this mainly to have an interlock against Windows signal thread.
+ * We need this mainly to have an interlock against the cancel handler thread.
  */
 static void
 set_cancel_pstate(ParallelState *pstate)
 {
-#ifdef WIN32
-	EnterCriticalSection(&signal_info_lock);
-#endif
-
+	LockCancelThread();
 	signal_info.pstate = pstate;
-
-#ifdef WIN32
-	LeaveCriticalSection(&signal_info_lock);
-#endif
+	UnlockCancelThread();
 }
 
 /*
  * set_cancel_slot_archive
  *
  * Set ParallelSlot's AH field to point to the specified archive, if any.
- * We need this mainly to have an interlock against Windows signal thread.
+ * We need this mainly to have an interlock against the cancel handler thread.
  */
 static void
 set_cancel_slot_archive(ParallelSlot *slot, ArchiveHandle *AH)
 {
-#ifdef WIN32
-	EnterCriticalSection(&signal_info_lock);
-#endif
-
+	LockCancelThread();
 	slot->AH = AH;
-
-#ifdef WIN32
-	LeaveCriticalSection(&signal_info_lock);
-#endif
+	UnlockCancelThread();
 }
 
 
@@ -929,7 +817,7 @@ ParallelBackupStart(ArchiveHandle *AH)
 
 	/*
 	 * Temporarily disable query cancellation on the leader connection.  This
-	 * ensures that child processes won't inherit valid AH->connCancel
+	 * ensures that child processes won't inherit valid AH->cancelConn
 	 * settings and thus won't try to issue cancels against the leader's
 	 * connection.  No harm is done if we fail while it's disabled, because
 	 * the leader connection is idle at this point anyway.
@@ -947,6 +835,7 @@ ParallelBackupStart(ArchiveHandle *AH)
 		uintptr_t	handle;
 #else
 		pid_t		pid;
+		sigset_t	cancel_set;
 #endif
 		ParallelSlot *slot = &(pstate->parallelSlot[i]);
 		int			pipeMW[2],
@@ -977,6 +866,18 @@ ParallelBackupStart(ArchiveHandle *AH)
 		slot->hThread = handle;
 		slot->workerStatus = WRKR_IDLE;
 #else							/* !WIN32 */
+
+		/*
+		 * Block signals before fork so that no signal can arrive in the child
+		 * before ResetCancelAfterFork() has cleaned up the inherited cancel
+		 * state (pipe fds, signal handlers, mutex).
+		 */
+		sigemptyset(&cancel_set);
+		sigaddset(&cancel_set, SIGINT);
+		sigaddset(&cancel_set, SIGTERM);
+		sigaddset(&cancel_set, SIGQUIT);
+		sigprocmask(SIG_BLOCK, &cancel_set, NULL);
+
 		pid = fork();
 		if (pid == 0)
 		{
@@ -988,6 +889,12 @@ ParallelBackupStart(ArchiveHandle *AH)
 
 			/* instruct signal handler that we're in a worker now */
 			signal_info.am_worker = true;
+
+			signal_info.handler_set = false;
+			ResetCancelAfterFork();
+			pqsignal(SIGTERM, PG_SIG_DFL);
+			pqsignal(SIGQUIT, PG_SIG_DFL);
+			sigprocmask(SIG_UNBLOCK, &cancel_set, NULL);
 
 			/* close read end of Worker -> Leader */
 			closesocket(pipeWM[PIPE_READ]);
@@ -1017,6 +924,8 @@ ParallelBackupStart(ArchiveHandle *AH)
 		}
 
 		/* In Leader after successful fork */
+		sigprocmask(SIG_UNBLOCK, &cancel_set, NULL);
+
 		slot->pid = pid;
 		slot->workerStatus = WRKR_IDLE;
 
@@ -1405,8 +1314,12 @@ ListenToWorkers(ArchiveHandle *AH, ParallelState *pstate, bool do_wait)
 
 	if (!msg)
 	{
-		/* If do_wait is true, we must have detected EOF on some socket */
-		if (do_wait)
+		/*
+		 * If do_wait is true, we must have detected EOF on some socket. If
+		 * it's due to a cancel request, that's expected, otherwise it's a
+		 * problem.
+		 */
+		if (do_wait && !CancelRequested)
 			pg_fatal("a worker process died unexpectedly");
 		return false;
 	}

--- a/src/bin/pg_dump/pg_backup_archiver.c
+++ b/src/bin/pg_dump/pg_backup_archiver.c
@@ -5198,7 +5198,7 @@ CloneArchive(ArchiveHandle *AH)
 
 	/* The clone will have its own connection, so disregard connection state */
 	clone->connection = NULL;
-	clone->connCancel = NULL;
+	clone->cancelConn = NULL;
 	clone->currUser = NULL;
 	clone->currSchema = NULL;
 	clone->currTableAm = NULL;

--- a/src/bin/pg_dump/pg_backup_archiver.h
+++ b/src/bin/pg_dump/pg_backup_archiver.h
@@ -288,8 +288,12 @@ struct _archiveHandle
 	char	   *savedPassword;	/* password for ropt->username, if known */
 	char	   *use_role;
 	PGconn	   *connection;
-	/* If connCancel isn't NULL, SIGINT handler will send a cancel */
-	PGcancel   *volatile connCancel;
+
+	/*
+	 * If cancelConn isn't NULL, SIGINT handler will trigger the cancel thread
+	 * to send a cancel.
+	 */
+	PGcancelConn *cancelConn;
 
 	int			connectToDB;	/* Flag to indicate if direct DB connection is
 								 * required */

--- a/src/bin/pg_dump/pg_backup_db.c
+++ b/src/bin/pg_dump/pg_backup_db.c
@@ -84,7 +84,7 @@ ReconnectToServer(ArchiveHandle *AH, const char *dbname)
 
 	/*
 	 * Note: we want to establish the new connection, and in particular update
-	 * ArchiveHandle's connCancel, before closing old connection.  Otherwise
+	 * ArchiveHandle's cancelConn, before closing old connection.  Otherwise
 	 * an ill-timed SIGINT could try to access a dead connection.
 	 */
 	AH->connection = NULL;		/* dodge error check in ConnectDatabaseAhx */
@@ -164,12 +164,11 @@ void
 DisconnectDatabase(Archive *AHX)
 {
 	ArchiveHandle *AH = (ArchiveHandle *) AHX;
-	char		errbuf[1];
 
 	if (!AH->connection)
 		return;
 
-	if (AH->connCancel)
+	if (AH->cancelConn)
 	{
 		/*
 		 * If we have an active query, send a cancel before closing, ignoring
@@ -177,7 +176,7 @@ DisconnectDatabase(Archive *AHX)
 		 * helpful during pg_fatal().
 		 */
 		if (PQtransactionStatus(AH->connection) == PQTRANS_ACTIVE)
-			(void) PQcancel(AH->connCancel, errbuf, sizeof(errbuf));
+			(void) PQcancelBlocking(AH->cancelConn);
 
 		/*
 		 * Prevent signal handler from sending a cancel after this.

--- a/src/bin/pgbench/pgbench.c
+++ b/src/bin/pgbench/pgbench.c
@@ -5333,7 +5333,7 @@ runInitSteps(const char *initialize_steps)
 	if ((con = doConnect()) == NULL)
 		pg_fatal("could not create connection for initialization");
 
-	setup_cancel_handler(NULL);
+	setup_cancel_handler(NULL, NULL);
 	SetCancelConn(con);
 
 	for (step = initialize_steps; *step != '\0'; step++)

--- a/src/bin/psql/command.c
+++ b/src/bin/psql/command.c
@@ -4405,7 +4405,7 @@ wait_until_connected(PGconn *conn)
 		 * On every iteration of the connection sequence, let's check if the
 		 * user has requested a cancellation.
 		 */
-		if (cancel_pressed)
+		if (CancelRequested)
 			break;
 
 		/*
@@ -4417,7 +4417,7 @@ wait_until_connected(PGconn *conn)
 			break;
 
 		/*
-		 * If the user sends SIGINT between the cancel_pressed check, and
+		 * If the user sends SIGINT between the CancelRequested check, and
 		 * polling of the socket, it will not be recognized. Instead, we will
 		 * just wait until the next step in the connection sequence or
 		 * forever, which might require users to send SIGTERM or SIGQUIT.
@@ -4428,7 +4428,7 @@ wait_until_connected(PGconn *conn)
 		 * The self-pipe trick requires a bit of code to setup. pselect(2) and
 		 * ppoll(2) are not on all the platforms we support. The simplest
 		 * solution happens to just be adding a timeout, so let's wait for 1
-		 * second and check cancel_pressed again.
+		 * second and check CancelRequested again.
 		 */
 		end_time = PQgetCurrentTimeUSec() + 1000000;
 		rc = PQsocketPoll(sock, forRead, !forRead, end_time);
@@ -6095,7 +6095,7 @@ do_watch(PQExpBuffer query_buf, double sleep, int iter, int min_rows)
 			long		s = Min(i, 1000L);
 
 			pg_usleep(s * 1000L);
-			if (cancel_pressed)
+			if (CancelRequested)
 			{
 				done = true;
 				break;
@@ -6105,7 +6105,7 @@ do_watch(PQExpBuffer query_buf, double sleep, int iter, int min_rows)
 #else
 		/* sigwait() will handle SIGINT. */
 		sigprocmask(SIG_BLOCK, &sigint, NULL);
-		if (cancel_pressed)
+		if (CancelRequested)
 			done = true;
 
 		/* Wait for SIGINT, SIGCHLD or SIGALRM. */

--- a/src/bin/psql/common.c
+++ b/src/bin/psql/common.c
@@ -307,23 +307,27 @@ volatile sig_atomic_t sigint_interrupt_enabled = false;
 
 sigjmp_buf	sigint_interrupt_jmp;
 
+#ifndef WIN32
 static void
 psql_cancel_callback(void)
 {
-#ifndef WIN32
 	/* if we are waiting for input, longjmp out of it */
 	if (sigint_interrupt_enabled)
 	{
 		sigint_interrupt_enabled = false;
 		siglongjmp(sigint_interrupt_jmp, 1);
 	}
-#endif
 }
+#endif
 
 void
 psql_setup_cancel_handler(void)
 {
-	setup_cancel_handler(psql_cancel_callback);
+#ifndef WIN32
+	setup_cancel_handler(psql_cancel_callback, NULL);
+#else
+	setup_cancel_handler(NULL, NULL);
+#endif
 }
 
 

--- a/src/bin/psql/common.c
+++ b/src/bin/psql/common.c
@@ -294,7 +294,7 @@ NoticeProcessor(void *arg, const char *message)
  *
  * SIGINT is supposed to abort all long-running psql operations, not only
  * database queries.  In most places, this is accomplished by checking
- * cancel_pressed during long-running loops.  However, that won't work when
+ * CancelRequested during long-running loops.  However, that won't work when
  * blocked on user input (in readline() or fgets()).  In those places, we
  * set sigint_interrupt_enabled true while blocked, instructing the signal
  * catcher to longjmp through sigint_interrupt_jmp.  We assume readline and
@@ -318,9 +318,6 @@ psql_cancel_callback(void)
 		siglongjmp(sigint_interrupt_jmp, 1);
 	}
 #endif
-
-	/* else, set cancel flag to stop any long-running loops */
-	cancel_pressed = true;
 }
 
 void
@@ -887,8 +884,8 @@ ExecQueryTuples(const PGresult *result)
 			{
 				const char *query = PQgetvalue(result, r, c);
 
-				/* Abandon execution if cancel_pressed */
-				if (cancel_pressed)
+				/* Abandon execution if CancelRequested */
+				if (CancelRequested)
 					goto loop_exit;
 
 				/*
@@ -1154,7 +1151,7 @@ SendQuery(const char *query, int num_copy_from_stdin)
 		if (fgets(buf, sizeof(buf), stdin) != NULL)
 			if (buf[0] == 'x')
 				goto sendquery_cleanup;
-		if (cancel_pressed)
+		if (CancelRequested)
 			goto sendquery_cleanup;
 	}
 	else if (pset.echo == PSQL_ECHO_QUERIES)
@@ -1781,7 +1778,7 @@ ExecQueryAndProcessResults(const char *query,
 	 * consumed.  The user's intention, though, is to cancel the entire watch
 	 * process, so detect a sent cancellation request and exit in this case.
 	 */
-	if (is_watch && cancel_pressed)
+	if (is_watch && CancelRequested)
 	{
 		ClearOrSaveAllResults();
 		return 0;
@@ -2070,7 +2067,7 @@ ExecQueryAndProcessResults(const char *query,
 				 * use of chunking for all cases in which PrintQueryResult
 				 * would send the result to someplace other than printQuery.
 				 */
-				if (success && !flush_error && !cancel_pressed)
+				if (success && !flush_error && !CancelRequested)
 				{
 					printQuery(result, &my_popt, tuples_fout, is_pager, pset.logfile);
 					flush_error = fflush(tuples_fout);
@@ -2097,7 +2094,7 @@ ExecQueryAndProcessResults(const char *query,
 				Assert(PQntuples(result) == 0);
 
 				/* Display the footer using the empty result */
-				if (success && !flush_error && !cancel_pressed)
+				if (success && !flush_error && !CancelRequested)
 				{
 					my_popt.topt.stop_table = true;
 					printQuery(result, &my_popt, tuples_fout, is_pager, pset.logfile);
@@ -2256,7 +2253,7 @@ ExecQueryAndProcessResults(const char *query,
 		ClearOrSaveResult(result);
 		result = next_result;
 
-		if (cancel_pressed && PQpipelineStatus(pset.db) == PQ_PIPELINE_OFF)
+		if (CancelRequested && PQpipelineStatus(pset.db) == PQ_PIPELINE_OFF)
 		{
 			/*
 			 * Outside of a pipeline, drop the next result, as well as any
@@ -2331,7 +2328,7 @@ ExecQueryAndProcessResults(const char *query,
 		num_copy_from_stdin--;
 	}
 
-	if (cancel_pressed || return_early)
+	if (CancelRequested || return_early)
 		return 0;
 
 	return success ? 1 : -1;

--- a/src/bin/psql/describe.c
+++ b/src/bin/psql/describe.c
@@ -32,6 +32,7 @@
 #include "common.h"
 #include "common/logging.h"
 #include "describe.h"
+#include "fe_utils/cancel.h"
 #include "fe_utils/mbprint.h"
 #include "fe_utils/print.h"
 #include "fe_utils/string_utils.h"
@@ -1513,7 +1514,7 @@ describeTableDetails(const char *pattern, bool verbose, bool showSystem)
 			PQclear(res);
 			return false;
 		}
-		if (cancel_pressed)
+		if (CancelRequested)
 		{
 			PQclear(res);
 			return false;
@@ -5509,7 +5510,7 @@ listTSParsersVerbose(const char *pattern)
 			return false;
 		}
 
-		if (cancel_pressed)
+		if (CancelRequested)
 		{
 			PQclear(res);
 			return false;
@@ -5899,7 +5900,7 @@ listTSConfigsVerbose(const char *pattern)
 			return false;
 		}
 
-		if (cancel_pressed)
+		if (CancelRequested)
 		{
 			PQclear(res);
 			return false;
@@ -6378,7 +6379,7 @@ listExtensionContents(const char *pattern)
 			PQclear(res);
 			return false;
 		}
-		if (cancel_pressed)
+		if (CancelRequested)
 		{
 			PQclear(res);
 			return false;

--- a/src/bin/psql/mainloop.c
+++ b/src/bin/psql/mainloop.c
@@ -10,6 +10,7 @@
 #include "command.h"
 #include "common.h"
 #include "common/logging.h"
+#include "fe_utils/cancel.h"
 #include "input.h"
 #include "mainloop.h"
 #include "mb/pg_wchar.h"
@@ -85,7 +86,7 @@ MainLoop(FILE *source)
 		/*
 		 * Clean up after a previous Control-C
 		 */
-		if (cancel_pressed)
+		if (CancelRequested)
 		{
 			if (!pset.cur_cmd_interactive)
 			{
@@ -96,7 +97,7 @@ MainLoop(FILE *source)
 				break;
 			}
 
-			cancel_pressed = false;
+			CancelRequested = false;
 		}
 
 		/*
@@ -118,7 +119,7 @@ MainLoop(FILE *source)
 			prompt_status = PROMPT_READY;
 			need_redisplay = false;
 			pset.stmt_lineno = 1;
-			cancel_pressed = false;
+			CancelRequested = false;
 
 			if (pset.cur_cmd_interactive)
 			{

--- a/src/bin/psql/variables.c
+++ b/src/bin/psql/variables.c
@@ -11,6 +11,7 @@
 
 #include "common.h"
 #include "common/logging.h"
+#include "fe_utils/cancel.h"
 #include "variables.h"
 
 /*
@@ -265,7 +266,7 @@ PrintVariables(VariableSpace space)
 	{
 		if (ptr->value)
 			printf("%s = '%s'\n", ptr->name, ptr->value);
-		if (cancel_pressed)
+		if (CancelRequested)
 			break;
 	}
 }

--- a/src/bin/scripts/clusterdb.c
+++ b/src/bin/scripts/clusterdb.c
@@ -140,7 +140,7 @@ main(int argc, char *argv[])
 	cparams.prompt_password = prompt_password;
 	cparams.override_dbname = NULL;
 
-	setup_cancel_handler(NULL);
+	setup_cancel_handler(NULL, NULL);
 
 	if (alldb)
 	{

--- a/src/bin/scripts/reindexdb.c
+++ b/src/bin/scripts/reindexdb.c
@@ -211,7 +211,7 @@ main(int argc, char *argv[])
 	cparams.prompt_password = prompt_password;
 	cparams.override_dbname = NULL;
 
-	setup_cancel_handler(NULL);
+	setup_cancel_handler(NULL, NULL);
 
 	if (concurrentCons > 1 && syscatalog)
 		pg_fatal("cannot use multiple jobs to reindex system catalogs");

--- a/src/bin/scripts/vacuuming.c
+++ b/src/bin/scripts/vacuuming.c
@@ -70,7 +70,7 @@ vacuuming_main(ConnParams *cparams, const char *dbname,
 			   unsigned int tbl_count, int concurrentCons,
 			   const char *progname)
 {
-	setup_cancel_handler(NULL);
+	setup_cancel_handler(NULL, NULL);
 
 	/* Avoid opening extra connections. */
 	if (tbl_count > 0 && (concurrentCons > tbl_count))

--- a/src/fe_utils/Makefile
+++ b/src/fe_utils/Makefile
@@ -17,7 +17,7 @@ subdir = src/fe_utils
 top_builddir = ../..
 include $(top_builddir)/src/Makefile.global
 
-override CPPFLAGS := -DFRONTEND -I$(libpq_srcdir) $(CPPFLAGS)
+override CPPFLAGS := -DFRONTEND -I$(libpq_srcdir) -I$(top_srcdir)/src/port $(CPPFLAGS)
 
 OBJS = \
 	archive.o \

--- a/src/fe_utils/cancel.c
+++ b/src/fe_utils/cancel.c
@@ -3,7 +3,7 @@
  * Query cancellation support for frontend code
  *
  * This module provides SIGINT/Ctrl-C handling for frontend tools that need to
- * cancel queries or interrupt other operations.  It provides three
+ * cancel queries or interrupt other operations.  It provides four
  * independent mechanisms, any combination of which can be used by an
  * application:
  *
@@ -13,9 +13,9 @@
  *    calling SetCancelConn() to register the connection that is (or will be)
  *    running the query, prior to waiting for the result.  When SIGINT/Ctrl-C
  *    is received, a cancel request for this connection will then be sent from
- *    the signal handler (on Windows, from a separate thread).  That in turn
- *    will then (assuming a co-operating server) cause the server to cancel
- *    the query and send an error to the waiting client on the main thread.
+ *    a separate thread.  That in turn will then (assuming a co-operating
+ *    server) cause the server to cancel the query and send an error to the
+ *    waiting client on the main thread.
  *    The cancel connection is a process-wide global, so only one connection
  *    can be the cancel target at a time.  ResetCancelConn() should be called
  *    to disarm the mechanism again after the blocking wait has completed.
@@ -26,11 +26,21 @@
  *    not blocked (indefinitely), but needs to take an action when Ctrl-C is
  *    pressed, such as break out of a long running loop.
  *
- * 3. Signal handler callback -- A callback function can be registered with
+ * 3. Thread handler callback -- A callback function can be registered with
+ *    setup_cancel_handler(), which will then be called whenever SIGINT is
+ *    received.  Unlike the signal handler callback below, it does not run in
+ *    the signal handler but in the same separate thread that sends the cancel
+ *    request (the dedicated cancel thread on Unix, the console handler thread
+ *    on Windows), so it need not be async-signal-safe.  That thread holds
+ *    cancel_thread_lock while the callback runs, so code sharing data with the
+ *    callback should take the same lock via
+ *    LockCancelThread()/UnlockCancelThread().
+ *
+ * 4. Signal handler callback -- A callback function can be registered with
  *    setup_cancel_handler(), which will then be called directly from the
  *    signal handler whenever SIGINT is received.  Because it is called from a
  *    signal handler, the callback function must be async-signal-safe.  On
- *    Windows, it is called from a separate signal-handling thread.  NOTE: The
+ *    Windows, this callback is never called.  NOTE: The
  *    callback is called AFTER setting CancelRequested but BEFORE sending the
  *    cancel request to the server (if armed by SetCancelConn).  This means
  *    that if the callback exits or longjmps, no cancel request will be sent
@@ -46,9 +56,21 @@
 
 #include "postgres_fe.h"
 
+#include <signal.h>
 #include <unistd.h>
 
+#ifndef WIN32
+#include <fcntl.h>
+#endif
+
+#ifdef WIN32
+#include "pthread-win32.h"
+#else
+#include <pthread.h>
+#endif
+
 #include "common/connect.h"
+#include "common/logging.h"
 #include "fe_utils/cancel.h"
 #include "fe_utils/string_utils.h"
 
@@ -66,11 +88,19 @@
 		(void) rc_; \
 	} while (0)
 
+
 /*
- * Contains all the information needed to cancel a query issued from
- * a database connection to the backend.
+ * Cancel connection that should be used to send cancel requests.
  */
-static PGcancel *volatile cancelConn = NULL;
+static PGcancelConn *cancelConn = NULL;
+
+/*
+ * Mutex held by the cancel thread for the duration of the cancel callback.
+ * SetCancelConn()/ResetCancelConn() on the main thread take this lock too,
+ * so they will wait for any in-flight cancel to finish before replacing or
+ * freeing cancelConn.
+ */
+static pthread_mutex_t cancel_thread_lock = PTHREAD_MUTEX_INITIALIZER;
 
 /*
  * Predetermined localized error strings --- needed to avoid trying
@@ -88,168 +118,183 @@ static const char *cancel_not_sent_msg = NULL;
  */
 volatile sig_atomic_t CancelRequested = false;
 
-#ifdef WIN32
-static CRITICAL_SECTION cancelConnLock;
-#endif
+/*
+ * Signal handler callback, called directly from signal handler context.
+ * Must be async-signal-safe.
+ */
+static void (*signal_callback_fn) (void) = NULL;
 
 /*
- * Additional callback for cancellations.
+ * Cancel thread callback, called from the cancel thread (Unix) or console
+ * handler (Windows) when a cancel signal is received.
  */
-static void (*cancel_callback) (void) = NULL;
+static void (*thread_callback_fn) (void) = NULL;
 
+#ifndef WIN32
+/*
+ * On Unix, the SIGINT signal handler cannot call PQcancelBlocking() directly
+ * because it is not async-signal-safe.  Instead, we use a pipe to wake a
+ * dedicated cancel thread: the signal handler writes a byte to the pipe, and
+ * the cancel thread's blocking read() returns, triggering the actual cancel
+ * request.
+ */
+static int	cancel_pipe[2] = {-1, -1};
+#endif
+
+
+/*
+ * Send a cancel request to the connection, if one is set.
+ *
+ * Called from the cancel thread (Unix) or the console handler thread
+ * (Windows), never from the signal handler itself.  The caller is
+ * responsible for holding cancel_thread_lock.
+ */
+static void
+SendCancelRequest(void)
+{
+	PGcancelConn *cc;
+
+	cc = cancelConn;
+	if (cc == NULL)
+		return;
+
+	if (PQcancelBlocking(cc))
+	{
+		write_stderr(cancel_sent_msg);
+	}
+	else
+	{
+		char	   *errmsg = PQcancelErrorMessage(cc);
+
+		write_stderr(cancel_not_sent_msg);
+		if (errmsg)
+			write_stderr(errmsg);
+	}
+
+	/* Reset for possible reuse */
+	PQcancelReset(cc);
+}
+
+
+/*
+ * Helper to replace cancelConn with a new value.
+ *
+ * Takes cancel_thread_lock, which also waits for any in-flight cancel
+ * callback to finish, since the cancel thread holds the same lock.
+ */
+static void
+SetCancelConnInternal(PGcancelConn *newCancelConn)
+{
+	PGcancelConn *oldCancelConn;
+
+	LockCancelThread();
+	oldCancelConn = cancelConn;
+	cancelConn = newCancelConn;
+	UnlockCancelThread();
+
+	if (oldCancelConn != NULL)
+		PQcancelFinish(oldCancelConn);
+}
 
 /*
  * SetCancelConn
  *
- * Set cancelConn to point to the current database connection.
+ * Set cancelConn to point to a cancel connection for the given database
+ * connection. This creates a new PGcancelConn that can be used to send
+ * cancel requests.
  */
 void
 SetCancelConn(PGconn *conn)
 {
-	PGcancel   *oldCancelConn;
-
-#ifdef WIN32
-	EnterCriticalSection(&cancelConnLock);
-#endif
-
-	/* Free the old one if we have one */
-	oldCancelConn = cancelConn;
-
-	/* be sure handle_sigint doesn't use pointer while freeing */
-	cancelConn = NULL;
-
-	if (oldCancelConn != NULL)
-		PQfreeCancel(oldCancelConn);
-
-	cancelConn = PQgetCancel(conn);
-
-#ifdef WIN32
-	LeaveCriticalSection(&cancelConnLock);
-#endif
+	SetCancelConnInternal(PQcancelCreate(conn));
 }
 
 /*
  * ResetCancelConn
  *
- * Free the current cancel connection, if any, and set to NULL.
+ * Clear cancelConn, preventing any pending cancel from being sent.
+ * Waits for any in-flight cancel request to complete first.
  */
 void
 ResetCancelConn(void)
 {
-	PGcancel   *oldCancelConn;
-
-#ifdef WIN32
-	EnterCriticalSection(&cancelConnLock);
-#endif
-
-	oldCancelConn = cancelConn;
-
-	/* be sure handle_sigint doesn't use pointer while freeing */
-	cancelConn = NULL;
-
-	if (oldCancelConn != NULL)
-		PQfreeCancel(oldCancelConn);
-
-#ifdef WIN32
-	LeaveCriticalSection(&cancelConnLock);
-#endif
+	SetCancelConnInternal(NULL);
 }
 
 
 /*
- * Code to support query cancellation
+ * LockCancelThread / UnlockCancelThread
  *
- * Note that sending the cancel directly from the signal handler is safe
- * because PQcancel() is written to make it so.  We use write() to report
- * to stderr because it's better to use simple facilities in a signal
- * handler.
- *
- * On Windows, the signal canceling happens on a separate thread, because
- * that's how SetConsoleCtrlHandler works.  The PQcancel function is safe
- * for this (unlike PQrequestCancel).  However, a CRITICAL_SECTION is required
- * to protect the PGcancel structure against being changed while the signal
- * thread is using it.
- */
-
-#ifndef WIN32
-
-/*
- * handle_sigint
- *
- * Handle interrupt signals by canceling the current command, if cancelConn
- * is set.
- */
-static void
-handle_sigint(SIGNAL_ARGS)
-{
-	char		errbuf[256];
-
-	CancelRequested = true;
-
-	if (cancel_callback != NULL)
-		cancel_callback();
-
-	/* Send QueryCancel if we are processing a database query */
-	if (cancelConn != NULL)
-	{
-		if (PQcancel(cancelConn, errbuf, sizeof(errbuf)))
-		{
-			write_stderr(cancel_sent_msg);
-		}
-		else
-		{
-			write_stderr(cancel_not_sent_msg);
-			write_stderr(errbuf);
-		}
-	}
-}
-
-/*
- * setup_cancel_handler
- *
- * Register query cancellation callback for SIGINT.
+ * Acquire or release cancel_thread_lock.  External callers (e.g. pg_dump)
+ * use these to protect shared data that the cancel-thread callback also
+ * accesses, without exposing the mutex directly.
  */
 void
-setup_cancel_handler(void (*query_cancel_callback) (void))
+LockCancelThread(void)
 {
-	cancel_callback = query_cancel_callback;
-	cancel_sent_msg = _("Cancel request sent\n");
-	cancel_not_sent_msg = _("Could not send cancel request: ");
-
-	pqsignal(SIGINT, handle_sigint);
+	pthread_mutex_lock(&cancel_thread_lock);
 }
 
-#else							/* WIN32 */
+void
+UnlockCancelThread(void)
+{
+	pthread_mutex_unlock(&cancel_thread_lock);
+}
 
+#ifndef WIN32
+/*
+ * ResetCancelAfterFork
+ *
+ * Reset cancel module state after fork(). Threads don't survive fork(), so the
+ * cancel thread and its pipe are gone. The mutex may have been held by the
+ * cancel thread at fork time, so we must reinitialize it rather than trying to
+ * unlock it.  cancelConn is NULLed without freeing because the parent process
+ * owns the underlying object.  The SIGINT handler is reset to SIG_DFL so that
+ * a signal arriving before setup_cancel_handler() is called again doesn't try
+ * to write to the closed pipe.
+ *
+ * The child will set up a fresh cancel thread when it later calls
+ * setup_cancel_handler().
+ */
+void
+ResetCancelAfterFork(void)
+{
+	close(cancel_pipe[0]);
+	close(cancel_pipe[1]);
+	cancel_pipe[0] = cancel_pipe[1] = -1;
+
+	pthread_mutex_init(&cancel_thread_lock, NULL);
+
+	cancelConn = NULL;
+	CancelRequested = false;
+
+	pqsignal(SIGINT, PG_SIG_DFL);
+}
+#endif
+
+#ifdef WIN32
+/*
+ * Console control handler for Windows.
+ *
+ * This runs in a separate thread created by the OS, so we can safely call
+ * the blocking cancel API directly.
+ */
 static BOOL WINAPI
 consoleHandler(DWORD dwCtrlType)
 {
-	char		errbuf[256];
-
 	if (dwCtrlType == CTRL_C_EVENT ||
 		dwCtrlType == CTRL_BREAK_EVENT)
 	{
 		CancelRequested = true;
 
-		if (cancel_callback != NULL)
-			cancel_callback();
+		LockCancelThread();
 
-		/* Send QueryCancel if we are processing a database query */
-		EnterCriticalSection(&cancelConnLock);
-		if (cancelConn != NULL)
-		{
-			if (PQcancel(cancelConn, errbuf, sizeof(errbuf)))
-			{
-				write_stderr(cancel_sent_msg);
-			}
-			else
-			{
-				write_stderr(cancel_not_sent_msg);
-				write_stderr(errbuf);
-			}
-		}
+		SendCancelRequest();
 
-		LeaveCriticalSection(&cancelConnLock);
+		if (thread_callback_fn != NULL)
+			thread_callback_fn();
+
+		UnlockCancelThread();
 
 		return TRUE;
 	}
@@ -258,16 +303,169 @@ consoleHandler(DWORD dwCtrlType)
 		return FALSE;
 }
 
+#else							/* !WIN32 */
+
+/*
+ * Signal handler that setup_cancel_handler configures for SIGINT. Exposed so
+ * other signals than SIGINT can use it if desired.
+ */
 void
-setup_cancel_handler(void (*callback) (void))
+CancelSignalHandler(SIGNAL_ARGS)
 {
-	cancel_callback = callback;
+	int			save_errno = errno;
+
+	CancelRequested = true;
+
+	if (signal_callback_fn != NULL)
+		signal_callback_fn();
+
+	/* Wake up the cancel thread */
+	if (cancel_pipe[1] >= 0)
+	{
+		char		c = 1;
+		int			rc = write(cancel_pipe[1], &c, 1);
+
+		(void) rc;
+	}
+
+	errno = save_errno;
+}
+
+/*
+ * Thread main function for create_cancel_thread.  Waits for the signal
+ * handler to write a byte to the pipe, then calls the cancel callback.
+ */
+static void *
+cancel_thread_loop(void *arg)
+{
+	for (;;)
+	{
+		char		buf[16];
+		ssize_t		rc;
+
+		rc = read(cancel_pipe[0], buf, sizeof(buf));
+		if (rc <= 0)
+		{
+			if (errno == EINTR)
+				continue;
+			/* Pipe closed or error - exit thread */
+			break;
+		}
+
+		LockCancelThread();
+
+		SendCancelRequest();
+
+		if (thread_callback_fn != NULL)
+			thread_callback_fn();
+
+		/*
+		 * Drain any pending bytes from the cancel pipe, so that signals
+		 * received while we were already handling a cancel don't cause us to
+		 * wake up again and cancel a subsequent query.
+		 */
+		fcntl(cancel_pipe[0], F_SETFL, O_NONBLOCK);
+		while (read(cancel_pipe[0], buf, sizeof(buf)) > 0)
+			;					/* loop until pipe is fully drained */
+		fcntl(cancel_pipe[0], F_SETFL, 0);
+
+		UnlockCancelThread();
+	}
+
+	return NULL;
+}
+
+/*
+ * create_cancel_thread
+ *
+ * Create a dedicated thread and associated pipe for async-signal-safe cancel
+ * handling.  The pipe allows signal handlers (which cannot safely call complex
+ * functions) to wake up the thread by writing a byte.
+ *
+ * The write end of the pipe is set non-blocking so signal handlers never
+ * block.  The thread is created with all signals blocked so that signals are
+ * always delivered to the main thread.  The thread runs until process exit.
+ * No handle is returned because currently no callers need to join it.
+ */
+static void
+create_cancel_thread(void)
+{
+	sigset_t	save_set;
+	sigset_t	block_set;
+	pthread_t	thread;
+	int			rc;
+
+	if (pipe(cancel_pipe) < 0)
+	{
+		pg_log_error("could not create pipe for cancel: %m");
+		exit(1);
+	}
+
+	/*
+	 * Make the write end non-blocking, so that the signal handler won't block
+	 * if the pipe buffer is full (which is very unlikely in practice but
+	 * possible in theory).
+	 */
+	fcntl(cancel_pipe[1], F_SETFL, O_NONBLOCK);
+
+	/*
+	 * Block all signals before creating the cancel thread, so that it
+	 * inherits a signal mask with all signals blocked.  This ensures signals
+	 * are always delivered to the main thread, which matters because some
+	 * signal_callback functions call siglongjmp() back to a sigsetjmp() on
+	 * the main thread's stack, specifically the psql_cancel_callback
+	 * function.
+	 */
+	sigfillset(&block_set);
+	pthread_sigmask(SIG_BLOCK, &block_set, &save_set);
+
+	rc = pthread_create(&thread, NULL, cancel_thread_loop, NULL);
+
+	pthread_sigmask(SIG_SETMASK, &save_set, NULL);
+
+	if (rc != 0)
+	{
+		pg_log_error("could not create cancel thread: %s", strerror(rc));
+		exit(1);
+	}
+
+	pthread_detach(thread);
+}
+
+#endif							/* !WIN32 */
+
+
+/*
+ * setup_cancel_handler
+ *
+ * Set up signal handling for SIGINT (Unix) or console events (Windows) to
+ * perform cancel actions.
+ *
+ * signal_callback is invoked directly from the signal handler context on
+ * every SIGINT (on Unix), so it must be async-signal-safe.  Can be NULL.
+ * On Windows, signal handlers don't exist (the console handler runs in a
+ * separate thread), so signal_callback must be NULL.
+ *
+ * thread_callback is invoked from a dedicated cancel thread (Unix) or the
+ * console handler thread (Windows) when a signal is received. Can be NULL.
+ */
+void
+setup_cancel_handler(void (*signal_callback) (void),
+					 void (*thread_callback) (void))
+{
+#ifdef WIN32
+	Assert(signal_callback == NULL);
+#endif
+
+	signal_callback_fn = signal_callback;
+	thread_callback_fn = thread_callback;
 	cancel_sent_msg = _("Cancel request sent\n");
 	cancel_not_sent_msg = _("Could not send cancel request: ");
 
-	InitializeCriticalSection(&cancelConnLock);
-
+#ifdef WIN32
 	SetConsoleCtrlHandler(consoleHandler, TRUE);
+#else
+	create_cancel_thread();
+	pqsignal(SIGINT, CancelSignalHandler);
+#endif
 }
-
-#endif							/* WIN32 */

--- a/src/fe_utils/parallel_slot.c
+++ b/src/fe_utils/parallel_slot.c
@@ -19,6 +19,10 @@
 #include "postgres_fe.h"
 
 #include <sys/select.h>
+#ifdef HAVE_PSELECT
+#include <pthread.h>
+#include <signal.h>
+#endif
 
 #include "common/logging.h"
 #include "fe_utils/cancel.h"
@@ -82,26 +86,55 @@ select_loop(int maxFd, fd_set *workerset)
 	int			i;
 	fd_set		saveSet = *workerset;
 
-	if (CancelRequested)
-		return -1;
+#ifdef HAVE_PSELECT
+
+	/*
+	 * On platforms that have it, we wait with pselect() rather than select(),
+	 * so that we can react to a cancel request without polling for it.  The
+	 * problem with plain select() is a race: SIGINT can arrive after we check
+	 * CancelRequested but before select() starts waiting, in which case
+	 * select() would keep waiting until a socket happens to become readable
+	 * (which for a stuck server might be never).  We close that race by
+	 * keeping SIGINT blocked around the CancelRequested check and having
+	 * pselect() unblock it (via origmask) only for the duration of the wait:
+	 * a SIGINT delivered in the race window stays pending and then interrupts
+	 * pselect() immediately with EINTR, so we loop around and bail out.
+	 */
+	sigset_t	origmask;
+	sigset_t	blockmask;
+
+	sigemptyset(&blockmask);
+	sigaddset(&blockmask, SIGINT);
+	pthread_sigmask(SIG_BLOCK, &blockmask, &origmask);
+#endif
 
 	for (;;)
 	{
-		/*
-		 * On Windows, we need to check once in a while for cancel requests;
-		 * on other platforms we rely on select() returning when interrupted.
-		 */
-		struct timeval *tvp;
-#ifdef WIN32
-		struct timeval tv = {0, 1000000};
-
-		tvp = &tv;
-#else
-		tvp = NULL;
-#endif
+		if (CancelRequested)
+		{
+			i = -1;
+			break;
+		}
 
 		*workerset = saveSet;
-		i = select(maxFd + 1, workerset, NULL, NULL, tvp);
+#ifdef HAVE_PSELECT
+		/* NULL timeout: wait indefinitely, relying on SIGINT to wake us. */
+		i = pselect(maxFd + 1, workerset, NULL, NULL, NULL, &origmask);
+#else
+
+		/*
+		 * Without pselect() we can't wait race-free, so add a timeout of 1
+		 * second to the select() and poll CancelRequested manually as a
+		 * fallback.  This also covers Windows, where a cancel request is
+		 * signalled by a separate console-handler thread rather than by
+		 * interrupting the wait.
+		 */
+		{
+			struct timeval tv = {0, 1000000};
+
+			i = select(maxFd + 1, workerset, NULL, NULL, &tv);
+		}
+#endif
 
 #ifdef WIN32
 		if (i == SOCKET_ERROR)
@@ -114,13 +147,18 @@ select_loop(int maxFd, fd_set *workerset)
 #endif
 
 		if (i < 0 && errno == EINTR)
-			continue;			/* ignore this */
-		if (i < 0 || CancelRequested)
-			return -1;			/* but not this */
+			continue;			/* interrupted, re-check CancelRequested */
 		if (i == 0)
-			continue;			/* timeout (Win32 only) */
-		break;
+			continue;			/* timeout (only reachable via select()) */
+		break;					/* ready sockets, or a hard error */
 	}
+
+#ifdef HAVE_PSELECT
+	pthread_sigmask(SIG_SETMASK, &origmask, NULL);
+#endif
+
+	if (i < 0)
+		return -1;
 
 	return i;
 }
@@ -197,8 +235,7 @@ wait_on_slots(ParallelSlotArray *sa)
 {
 	int			i;
 	fd_set		slotset;
-	int			maxFd = 0;
-	PGconn	   *cancelconn = NULL;
+	int			maxFd = -1;
 
 	/* We must reconstruct the fd_set for each call to select_loop */
 	FD_ZERO(&slotset);
@@ -219,10 +256,6 @@ wait_on_slots(ParallelSlotArray *sa)
 		if (sock < 0)
 			continue;
 
-		/* Keep track of the first valid connection we see. */
-		if (cancelconn == NULL)
-			cancelconn = sa->slots[i].connection;
-
 		FD_SET(sock, &slotset);
 		if (sock > maxFd)
 			maxFd = sock;
@@ -232,12 +265,10 @@ wait_on_slots(ParallelSlotArray *sa)
 	 * If we get this far with no valid connections, processing cannot
 	 * continue.
 	 */
-	if (cancelconn == NULL)
+	if (maxFd < 0)
 		return false;
 
-	SetCancelConn(cancelconn);
 	i = select_loop(maxFd, &slotset);
-	ResetCancelConn();
 
 	/* failure? */
 	if (i < 0)

--- a/src/fe_utils/print.c
+++ b/src/fe_utils/print.c
@@ -4,7 +4,7 @@
  *
  * This file used to be part of psql, but now it's separated out to allow
  * other frontend programs to use it.  Because the printing code needs
- * access to the cancel_pressed flag as well as SIGPIPE trapping and
+ * access to the CancelRequested flag as well as SIGPIPE trapping and
  * pager open/close functions, all that stuff came with it.
  *
  *
@@ -31,6 +31,7 @@
 
 #include "catalog/pg_type_d.h"
 #include "common/logging.h"
+#include "fe_utils/cancel.h"
 #include "fe_utils/mbprint.h"
 #include "fe_utils/print.h"
 
@@ -40,13 +41,9 @@
 #endif
 
 /*
- * If the calling program doesn't have any mechanism for setting
- * cancel_pressed, it will have no effect.
- *
- * Note: print.c's general strategy for when to check cancel_pressed is to do
+ * Note: print.c's general strategy for when to check CancelRequested is to do
  * so at completion of each row of output.
  */
-volatile sig_atomic_t cancel_pressed = false;
 
 static bool always_ignore_sigpipe = false;
 
@@ -443,7 +440,7 @@ print_unaligned_text(const printTableContent *cont, FILE *fout)
 	const char *const *ptr;
 	bool		need_recordsep = false;
 
-	if (cancel_pressed)
+	if (CancelRequested)
 		return;
 
 	if (cont->opt->start_table)
@@ -478,7 +475,7 @@ print_unaligned_text(const printTableContent *cont, FILE *fout)
 		{
 			print_separator(cont->opt->recordSep, fout);
 			need_recordsep = false;
-			if (cancel_pressed)
+			if (CancelRequested)
 				break;
 		}
 		fputs(*ptr, fout);
@@ -494,7 +491,7 @@ print_unaligned_text(const printTableContent *cont, FILE *fout)
 	{
 		printTableFooter *footers = footers_with_default(cont);
 
-		if (!opt_tuples_only && footers != NULL && !cancel_pressed)
+		if (!opt_tuples_only && footers != NULL && !CancelRequested)
 		{
 			printTableFooter *f;
 
@@ -534,7 +531,7 @@ print_unaligned_vertical(const printTableContent *cont, FILE *fout)
 	const char *const *ptr;
 	bool		need_recordsep = false;
 
-	if (cancel_pressed)
+	if (CancelRequested)
 		return;
 
 	if (cont->opt->start_table)
@@ -559,7 +556,7 @@ print_unaligned_vertical(const printTableContent *cont, FILE *fout)
 			print_separator(cont->opt->recordSep, fout);
 			print_separator(cont->opt->recordSep, fout);
 			need_recordsep = false;
-			if (cancel_pressed)
+			if (CancelRequested)
 				break;
 		}
 
@@ -576,7 +573,7 @@ print_unaligned_vertical(const printTableContent *cont, FILE *fout)
 	if (cont->opt->stop_table)
 	{
 		/* print footers */
-		if (!opt_tuples_only && cont->footers != NULL && !cancel_pressed)
+		if (!opt_tuples_only && cont->footers != NULL && !CancelRequested)
 		{
 			printTableFooter *f;
 
@@ -684,7 +681,7 @@ print_aligned_text(const printTableContent *cont, FILE *fout, bool is_pager)
 	int			output_columns = 0; /* Width of interactive console */
 	bool		is_local_pager = false;
 
-	if (cancel_pressed)
+	if (CancelRequested)
 		return;
 
 	if (opt_border > 2)
@@ -1005,7 +1002,7 @@ print_aligned_text(const printTableContent *cont, FILE *fout, bool is_pager)
 	{
 		bool		more_lines;
 
-		if (cancel_pressed)
+		if (CancelRequested)
 			break;
 
 		/*
@@ -1161,12 +1158,12 @@ print_aligned_text(const printTableContent *cont, FILE *fout, bool is_pager)
 	{
 		printTableFooter *footers = footers_with_default(cont);
 
-		if (opt_border == 2 && !cancel_pressed)
+		if (opt_border == 2 && !CancelRequested)
 			_print_horizontal_line(col_count, width_wrap, opt_border,
 								   PRINT_RULE_BOTTOM, format, fout);
 
 		/* print footers */
-		if (footers && !opt_tuples_only && !cancel_pressed)
+		if (footers && !opt_tuples_only && !CancelRequested)
 		{
 			printTableFooter *f;
 
@@ -1326,7 +1323,7 @@ print_aligned_vertical(const printTableContent *cont,
 				dmultiline = false;
 	int			output_columns = 0; /* Width of interactive console */
 
-	if (cancel_pressed)
+	if (CancelRequested)
 		return;
 
 	if (opt_border > 2)
@@ -1342,7 +1339,7 @@ print_aligned_vertical(const printTableContent *cont,
 	{
 		printTableFooter *footers = footers_with_default(cont);
 
-		if (!opt_tuples_only && !cancel_pressed && footers)
+		if (!opt_tuples_only && !CancelRequested && footers)
 		{
 			printTableFooter *f;
 
@@ -1598,7 +1595,7 @@ print_aligned_vertical(const printTableContent *cont,
 					offset,
 					chars_to_output;
 
-		if (cancel_pressed)
+		if (CancelRequested)
 			break;
 
 		if (i == 0)
@@ -1807,12 +1804,12 @@ print_aligned_vertical(const printTableContent *cont,
 
 	if (cont->opt->stop_table)
 	{
-		if (opt_border == 2 && !cancel_pressed)
+		if (opt_border == 2 && !CancelRequested)
 			print_aligned_vertical_line(cont->opt, 0, hwidth, dwidth,
 										output_columns, PRINT_RULE_BOTTOM, fout);
 
 		/* print footers */
-		if (!opt_tuples_only && cont->footers != NULL && !cancel_pressed)
+		if (!opt_tuples_only && cont->footers != NULL && !CancelRequested)
 		{
 			printTableFooter *f;
 
@@ -1886,7 +1883,7 @@ print_csv_text(const printTableContent *cont, FILE *fout)
 	const char *const *ptr;
 	int			i;
 
-	if (cancel_pressed)
+	if (CancelRequested)
 		return;
 
 	/*
@@ -1929,7 +1926,7 @@ print_csv_vertical(const printTableContent *cont, FILE *fout)
 	/* print records */
 	for (i = 0, ptr = cont->cells; *ptr; i++, ptr++)
 	{
-		if (cancel_pressed)
+		if (CancelRequested)
 			return;
 
 		/* print name of column */
@@ -2002,7 +1999,7 @@ print_html_text(const printTableContent *cont, FILE *fout)
 	unsigned int i;
 	const char *const *ptr;
 
-	if (cancel_pressed)
+	if (CancelRequested)
 		return;
 
 	if (cont->opt->start_table)
@@ -2039,7 +2036,7 @@ print_html_text(const printTableContent *cont, FILE *fout)
 	{
 		if (i % cont->ncolumns == 0)
 		{
-			if (cancel_pressed)
+			if (CancelRequested)
 				break;
 			fputs("  <tr valign=\"top\">\n", fout);
 		}
@@ -2064,7 +2061,7 @@ print_html_text(const printTableContent *cont, FILE *fout)
 		fputs("</table>\n", fout);
 
 		/* print footers */
-		if (!opt_tuples_only && footers != NULL && !cancel_pressed)
+		if (!opt_tuples_only && footers != NULL && !CancelRequested)
 		{
 			printTableFooter *f;
 
@@ -2092,7 +2089,7 @@ print_html_vertical(const printTableContent *cont, FILE *fout)
 	unsigned int i;
 	const char *const *ptr;
 
-	if (cancel_pressed)
+	if (CancelRequested)
 		return;
 
 	if (cont->opt->start_table)
@@ -2116,7 +2113,7 @@ print_html_vertical(const printTableContent *cont, FILE *fout)
 	{
 		if (i % cont->ncolumns == 0)
 		{
-			if (cancel_pressed)
+			if (CancelRequested)
 				break;
 			if (!opt_tuples_only)
 				fprintf(fout,
@@ -2145,7 +2142,7 @@ print_html_vertical(const printTableContent *cont, FILE *fout)
 		fputs("</table>\n", fout);
 
 		/* print footers */
-		if (!opt_tuples_only && cont->footers != NULL && !cancel_pressed)
+		if (!opt_tuples_only && cont->footers != NULL && !CancelRequested)
 		{
 			printTableFooter *f;
 
@@ -2194,7 +2191,7 @@ print_asciidoc_text(const printTableContent *cont, FILE *fout)
 	unsigned int i;
 	const char *const *ptr;
 
-	if (cancel_pressed)
+	if (CancelRequested)
 		return;
 
 	if (cont->opt->start_table)
@@ -2253,7 +2250,7 @@ print_asciidoc_text(const printTableContent *cont, FILE *fout)
 	{
 		if (i % cont->ncolumns == 0)
 		{
-			if (cancel_pressed)
+			if (CancelRequested)
 				break;
 		}
 
@@ -2281,7 +2278,7 @@ print_asciidoc_text(const printTableContent *cont, FILE *fout)
 		printTableFooter *footers = footers_with_default(cont);
 
 		/* print footers */
-		if (!opt_tuples_only && footers != NULL && !cancel_pressed)
+		if (!opt_tuples_only && footers != NULL && !CancelRequested)
 		{
 			printTableFooter *f;
 
@@ -2305,7 +2302,7 @@ print_asciidoc_vertical(const printTableContent *cont, FILE *fout)
 	unsigned int i;
 	const char *const *ptr;
 
-	if (cancel_pressed)
+	if (CancelRequested)
 		return;
 
 	if (cont->opt->start_table)
@@ -2344,7 +2341,7 @@ print_asciidoc_vertical(const printTableContent *cont, FILE *fout)
 	{
 		if (i % cont->ncolumns == 0)
 		{
-			if (cancel_pressed)
+			if (CancelRequested)
 				break;
 			if (!opt_tuples_only)
 				fprintf(fout,
@@ -2371,7 +2368,7 @@ print_asciidoc_vertical(const printTableContent *cont, FILE *fout)
 	if (cont->opt->stop_table)
 	{
 		/* print footers */
-		if (!opt_tuples_only && cont->footers != NULL && !cancel_pressed)
+		if (!opt_tuples_only && cont->footers != NULL && !CancelRequested)
 		{
 			printTableFooter *f;
 
@@ -2462,7 +2459,7 @@ print_latex_text(const printTableContent *cont, FILE *fout)
 	unsigned int i;
 	const char *const *ptr;
 
-	if (cancel_pressed)
+	if (CancelRequested)
 		return;
 
 	if (opt_border > 3)
@@ -2523,7 +2520,7 @@ print_latex_text(const printTableContent *cont, FILE *fout)
 			fputs(" \\\\\n", fout);
 			if (opt_border == 3)
 				fputs("\\hline\n", fout);
-			if (cancel_pressed)
+			if (CancelRequested)
 				break;
 		}
 		else
@@ -2540,7 +2537,7 @@ print_latex_text(const printTableContent *cont, FILE *fout)
 		fputs("\\end{tabular}\n\n\\noindent ", fout);
 
 		/* print footers */
-		if (footers && !opt_tuples_only && !cancel_pressed)
+		if (footers && !opt_tuples_only && !CancelRequested)
 		{
 			printTableFooter *f;
 
@@ -2572,7 +2569,7 @@ print_latex_longtable_text(const printTableContent *cont, FILE *fout)
 	const char *last_opt_table_attr_char = NULL;
 	const char *const *ptr;
 
-	if (cancel_pressed)
+	if (CancelRequested)
 		return;
 
 	if (opt_border > 3)
@@ -2708,7 +2705,7 @@ print_latex_longtable_text(const printTableContent *cont, FILE *fout)
 			if (opt_border == 3)
 				fputs(" \\hline\n", fout);
 		}
-		if (cancel_pressed)
+		if (CancelRequested)
 			break;
 	}
 
@@ -2726,7 +2723,7 @@ print_latex_vertical(const printTableContent *cont, FILE *fout)
 	unsigned int i;
 	const char *const *ptr;
 
-	if (cancel_pressed)
+	if (CancelRequested)
 		return;
 
 	if (opt_border > 2)
@@ -2759,7 +2756,7 @@ print_latex_vertical(const printTableContent *cont, FILE *fout)
 		/* new record */
 		if (i % cont->ncolumns == 0)
 		{
-			if (cancel_pressed)
+			if (CancelRequested)
 				break;
 			if (!opt_tuples_only)
 			{
@@ -2789,7 +2786,7 @@ print_latex_vertical(const printTableContent *cont, FILE *fout)
 		fputs("\\end{tabular}\n\n\\noindent ", fout);
 
 		/* print footers */
-		if (cont->footers && !opt_tuples_only && !cancel_pressed)
+		if (cont->footers && !opt_tuples_only && !CancelRequested)
 		{
 			printTableFooter *f;
 
@@ -2835,7 +2832,7 @@ print_troff_ms_text(const printTableContent *cont, FILE *fout)
 	unsigned int i;
 	const char *const *ptr;
 
-	if (cancel_pressed)
+	if (CancelRequested)
 		return;
 
 	if (opt_border > 2)
@@ -2889,7 +2886,7 @@ print_troff_ms_text(const printTableContent *cont, FILE *fout)
 		if ((i + 1) % cont->ncolumns == 0)
 		{
 			fputc('\n', fout);
-			if (cancel_pressed)
+			if (CancelRequested)
 				break;
 		}
 		else
@@ -2903,7 +2900,7 @@ print_troff_ms_text(const printTableContent *cont, FILE *fout)
 		fputs(".TE\n.DS L\n", fout);
 
 		/* print footers */
-		if (footers && !opt_tuples_only && !cancel_pressed)
+		if (footers && !opt_tuples_only && !CancelRequested)
 		{
 			printTableFooter *f;
 
@@ -2929,7 +2926,7 @@ print_troff_ms_vertical(const printTableContent *cont, FILE *fout)
 	const char *const *ptr;
 	unsigned short current_format = 0;	/* 0=none, 1=header, 2=body */
 
-	if (cancel_pressed)
+	if (CancelRequested)
 		return;
 
 	if (opt_border > 2)
@@ -2965,7 +2962,7 @@ print_troff_ms_vertical(const printTableContent *cont, FILE *fout)
 		/* new record */
 		if (i % cont->ncolumns == 0)
 		{
-			if (cancel_pressed)
+			if (CancelRequested)
 				break;
 			if (!opt_tuples_only)
 			{
@@ -3010,7 +3007,7 @@ print_troff_ms_vertical(const printTableContent *cont, FILE *fout)
 		fputs(".TE\n.DS L\n", fout);
 
 		/* print footers */
-		if (cont->footers && !opt_tuples_only && !cancel_pressed)
+		if (cont->footers && !opt_tuples_only && !CancelRequested)
 		{
 			printTableFooter *f;
 
@@ -3188,7 +3185,7 @@ ClosePager(FILE *pagerpipe)
 		 * pager quit as a result of the SIGINT, this message won't go
 		 * anywhere ...
 		 */
-		if (cancel_pressed)
+		if (CancelRequested)
 			fprintf(pagerpipe, _("Interrupted\n"));
 
 		pclose(pagerpipe);
@@ -3693,7 +3690,7 @@ printTable(const printTableContent *cont,
 {
 	bool		is_local_pager = false;
 
-	if (cancel_pressed)
+	if (CancelRequested)
 		return;
 
 	if (cont->opt->format == PRINT_NOTHING)
@@ -3801,7 +3798,7 @@ printQuery(const PGresult *result, const printQueryOpt *opt,
 				r,
 				c;
 
-	if (cancel_pressed)
+	if (CancelRequested)
 		return;
 
 	printTableInit(&cont, &opt->topt, opt->title,

--- a/src/include/fe_utils/cancel.h
+++ b/src/include/fe_utils/cancel.h
@@ -23,10 +23,15 @@ extern PGDLLIMPORT volatile sig_atomic_t CancelRequested;
 extern void SetCancelConn(PGconn *conn);
 extern void ResetCancelConn(void);
 
-/*
- * A callback can be optionally set up to be called at cancellation
- * time.
- */
-extern void setup_cancel_handler(void (*query_cancel_callback) (void));
+extern void setup_cancel_handler(void (*signal_callback) (void),
+								 void (*thread_callback) (void));
+
+extern void LockCancelThread(void);
+extern void UnlockCancelThread(void);
+
+#ifndef WIN32
+extern void ResetCancelAfterFork(void);
+extern void CancelSignalHandler(SIGNAL_ARGS);
+#endif
 
 #endif							/* CANCEL_H */

--- a/src/include/fe_utils/print.h
+++ b/src/include/fe_utils/print.h
@@ -194,8 +194,6 @@ typedef struct printQueryOpt
 } printQueryOpt;
 
 
-extern PGDLLIMPORT volatile sig_atomic_t cancel_pressed;
-
 extern PGDLLIMPORT const printTextFormat pg_asciiformat;
 extern PGDLLIMPORT const printTextFormat pg_asciiformat_old;
 extern PGDLLIMPORT printTextFormat pg_utf8format;	/* ideally would be const,

--- a/src/include/pg_config.h.in
+++ b/src/include/pg_config.h.in
@@ -309,6 +309,9 @@
 /* Define to 1 if you have the `ppoll' function. */
 #undef HAVE_PPOLL
 
+/* Define to 1 if you have the `pselect' function. */
+#undef HAVE_PSELECT
+
 /* Define if you have POSIX threads libraries and header files. */
 #undef HAVE_PTHREAD
 

--- a/src/interfaces/libpq/Makefile
+++ b/src/interfaces/libpq/Makefile
@@ -75,7 +75,6 @@ endif
 
 ifeq ($(PORTNAME), win32)
 OBJS += \
-	pthread-win32.o \
 	win32.o
 endif
 

--- a/src/interfaces/libpq/meson.build
+++ b/src/interfaces/libpq/meson.build
@@ -20,7 +20,7 @@ libpq_sources = files(
 libpq_so_sources = [] # for shared lib, in addition to the above
 
 if host_system == 'windows'
-  libpq_sources += files('pthread-win32.c', 'win32.c')
+  libpq_sources += files('win32.c')
   libpq_so_sources += rc_lib_gen.process(win32ver_rc, extra_args: [
     '--NAME', 'libpq',
     '--FILEDESC', 'PostgreSQL Access Library',])

--- a/src/port/meson.build
+++ b/src/port/meson.build
@@ -33,6 +33,7 @@ if host_system == 'windows'
     'dirmod.c',
     'kill.c',
     'open.c',
+    'pthread-win32.c',
     'system.c',
     'win32common.c',
     'win32dlopen.c',

--- a/src/port/pthread-win32.c
+++ b/src/port/pthread-win32.c
@@ -5,12 +5,12 @@
 *
 * Copyright (c) 2004-2026, PostgreSQL Global Development Group
 * IDENTIFICATION
-*	src/interfaces/libpq/pthread-win32.c
+*	src/port/pthread-win32.c
 *
 *-------------------------------------------------------------------------
 */
 
-#include "postgres_fe.h"
+#include "c.h"
 
 #include "pthread-win32.h"
 


### PR DESCRIPTION
- **psql: Replace cancel_pressed with CancelRequested**
- **fe_utils: Simplify cancel logic in wait_on_slots**
- **Move Windows pthread compatibility functions to src/port**
- **Don't use deprecated and insecure PQcancel psql and other tools anymore**
