### PR TITLE
non lossy exact match

### DIFF
--- a/src/backend/utils/adt/like_support.c
+++ b/src/backend/utils/adt/like_support.c
@@ -79,7 +79,8 @@ static List *match_pattern_prefix(Node *leftop,
 								  Pattern_Type ptype,
 								  Oid expr_coll,
 								  Oid opfamily,
-								  Oid indexcollation);
+								  Oid indexcollation,
+								  bool *lossy);
 static double patternsel_common(PlannerInfo *root,
 								Oid oprid,
 								Oid opfuncid,
@@ -215,7 +216,8 @@ like_regex_support(Node *rawreq, Pattern_Type ptype)
 									 ptype,
 									 clause->inputcollid,
 									 req->opfamily,
-									 req->indexcollation);
+									 req->indexcollation,
+									 &req->lossy);
 		}
 		else if (is_funcclause(req->node))	/* be paranoid */
 		{
@@ -228,7 +230,8 @@ like_regex_support(Node *rawreq, Pattern_Type ptype)
 									 ptype,
 									 clause->inputcollid,
 									 req->opfamily,
-									 req->indexcollation);
+									 req->indexcollation,
+									 &req->lossy);
 		}
 	}
 
@@ -245,7 +248,8 @@ match_pattern_prefix(Node *leftop,
 					 Pattern_Type ptype,
 					 Oid expr_coll,
 					 Oid opfamily,
-					 Oid indexcollation)
+					 Oid indexcollation,
+					 bool *lossy)
 {
 	List	   *result;
 	Const	   *patt;
@@ -391,8 +395,8 @@ match_pattern_prefix(Node *leftop,
 	 * It doesn't matter whether the index collation is deterministic or not:
 	 * if it's deterministic it agrees on equality with the expression
 	 * collation, and if it's nondeterministic the "=" indexqual merely treats
-	 * a superset of values as equal.  The latter is fine because the
-	 * indexqual is lossy (the original pattern is rechecked), so the recheck
+	 * a superset of values as equal.  The latter is fine because we keep the
+	 * indexqual as lossy (the original pattern is rechecked), so the recheck
 	 * filters out the rows where the index collation disagrees with the
 	 * expression collation.  A nondeterministic expression collation, on the
 	 * other hand, is only safe when the index uses that exact same collation,
@@ -405,6 +409,35 @@ match_pattern_prefix(Node *leftop,
 			return NIL;
 		if (indexcollation != expr_coll && NONDETERMINISTIC(expr_coll))
 			return NIL;
+
+		/*
+		 * The "=" indexqual is normally treated as lossy (the original
+		 * pattern is rechecked) because "=" can match rows that the pattern
+		 * does not.  But the recheck can be skipped when "=" means exactly
+		 * the exact-match pattern: that is, for a non-blank-padded type, when
+		 * the index and expression collations agree on equality (they're the
+		 * same collation, or both deterministic).  bpchar is excluded because
+		 * its "=" ignores trailing blanks, and a nondeterministic index
+		 * collation that differs from the expression's is excluded because
+		 * then "=" matches a superset of the pattern; both of those need the
+		 * recheck.
+		 *
+		 * We must also keep the recheck when the expression has no collation
+		 * (InvalidOid) but the index does.  That happens for a collatable
+		 * expression whose collation is indeterminate (e.g. a concatenation
+		 * of differently-collated columns): the pattern match would error out
+		 * with "could not determine which collation to use", and dropping the
+		 * recheck would let the "=" indexqual silently resolve the comparison
+		 * under the index's collation instead.  When the expression is a
+		 * genuinely non-collatable type (bytea) the index collation is
+		 * InvalidOid too, so indexcollation == expr_coll and we still
+		 * optimize.
+		 */
+		if (ldatatype != BPCHAROID &&
+			(indexcollation == expr_coll || OidIsValid(expr_coll)) &&
+			collations_agree_on_equality(indexcollation, expr_coll))
+			*lossy = false;
+
 		expr = make_opclause(eqopr, BOOLOID, false,
 							 (Expr *) leftop, (Expr *) prefix,
 							 InvalidOid, indexcollation);

--- a/src/backend/utils/adt/like_support.c
+++ b/src/backend/utils/adt/like_support.c
@@ -69,6 +69,10 @@ typedef enum
 	Pattern_Prefix_None, Pattern_Prefix_Partial, Pattern_Prefix_Exact,
 } Pattern_Prefix_Status;
 
+/* non-collatable comparisons, eg for bytea, are always deterministic */
+#define NONDETERMINISTIC(coll) \
+	(OidIsValid(coll) && !get_collation_isdeterministic(coll))
+
 static Node *like_regex_support(Node *rawreq, Pattern_Type ptype);
 static List *match_pattern_prefix(Node *leftop,
 								  Node *rightop,
@@ -381,12 +385,25 @@ match_pattern_prefix(Node *leftop,
 	 * us to not be concerned with specific opclasses (except for the legacy
 	 * "pattern" cases); any index that correctly implements the operators
 	 * will work.
+	 *
+	 * Also, we can use an index whose collation differs from the
+	 * expression's, so long as the expression's collation is deterministic.
+	 * It doesn't matter whether the index collation is deterministic or not:
+	 * if it's deterministic it agrees on equality with the expression
+	 * collation, and if it's nondeterministic the "=" indexqual merely treats
+	 * a superset of values as equal.  The latter is fine because the
+	 * indexqual is lossy (the original pattern is rechecked), so the recheck
+	 * filters out the rows where the index collation disagrees with the
+	 * expression collation.  A nondeterministic expression collation, on the
+	 * other hand, is only safe when the index uses that exact same collation,
+	 * since otherwise the indexqual could omit matching rows.  Otherwise,
+	 * fail quietly.
 	 */
 	if (pstatus == Pattern_Prefix_Exact)
 	{
 		if (!op_in_opfamily(eqopr, opfamily))
 			return NIL;
-		if (indexcollation != expr_coll)
+		if (indexcollation != expr_coll && NONDETERMINISTIC(expr_coll))
 			return NIL;
 		expr = make_opclause(eqopr, BOOLOID, false,
 							 (Expr *) leftop, (Expr *) prefix,
@@ -400,10 +417,8 @@ match_pattern_prefix(Node *leftop,
 	 * expression collation is nondeterministic.  The optimized equality or
 	 * prefix tests use bytewise comparisons, which is not consistent with
 	 * nondeterministic collations.
-	 *
-	 * expr_coll is not set for a non-collation-aware data type such as bytea.
 	 */
-	if (expr_coll && !get_collation_isdeterministic(expr_coll))
+	if (NONDETERMINISTIC(expr_coll))
 		return NIL;
 
 	/*

--- a/src/test/regress/expected/collate.icu.utf8.out
+++ b/src/test/regress/expected/collate.icu.utf8.out
@@ -1561,6 +1561,25 @@ SELECT x FROM test3cs WHERE x ~ 'a';
  abc
 (1 row)
 
+-- An exact-match regex is converted to an "=" indexqual.  We can use an index
+-- whose collation differs from the expression's as long as the expression's
+-- collation is deterministic, even when the index's collation is
+-- nondeterministic.  Check that we get an index scan rather than a seqscan.
+CREATE INDEX test3cs_ci ON test3cs (x COLLATE case_insensitive);
+SET enable_seqscan = off;
+SET enable_bitmapscan = off;
+EXPLAIN (costs off)
+SELECT x FROM test3cs WHERE x ~ '^(abc)$';
+                 QUERY PLAN                  
+---------------------------------------------
+ Index Only Scan using test3cs_ci on test3cs
+   Index Cond: (x = 'abc'::text)
+   Filter: (x ~ '^(abc)$'::text)
+(3 rows)
+
+RESET enable_seqscan;
+RESET enable_bitmapscan;
+DROP INDEX test3cs_ci;
 SET enable_hashagg TO off;
 SELECT x FROM test1cs UNION SELECT x FROM test2cs ORDER BY x;
   x  

--- a/src/test/regress/expected/collate.icu.utf8.out
+++ b/src/test/regress/expected/collate.icu.utf8.out
@@ -1577,6 +1577,24 @@ SELECT x FROM test3cs WHERE x ~ '^(abc)$';
    Filter: (x ~ '^(abc)$'::text)
 (3 rows)
 
+-- When the expression uses the same (nondeterministic) collation as the index,
+-- the "=" indexqual means exactly what the exact-match pattern does, so the
+-- recheck Filter is dropped even though the collation is nondeterministic.
+EXPLAIN (costs off)
+SELECT x FROM test3cs WHERE x COLLATE case_insensitive LIKE 'abc';
+                 QUERY PLAN                  
+---------------------------------------------
+ Index Only Scan using test3cs_ci on test3cs
+   Index Cond: (x = 'abc'::text)
+(2 rows)
+
+SELECT x FROM test3cs WHERE x COLLATE case_insensitive LIKE 'abc' ORDER BY x;
+  x  
+-----
+ abc
+ ABC
+(2 rows)
+
 RESET enable_seqscan;
 RESET enable_bitmapscan;
 DROP INDEX test3cs_ci;

--- a/src/test/regress/expected/collate.out
+++ b/src/test/regress/expected/collate.out
@@ -768,13 +768,32 @@ DETAIL:  LOCALE cannot be specified together with LC_COLLATE or LC_CTYPE.
 CREATE COLLATION coll_dup_chk (FROM = "C", VERSION = "1");
 ERROR:  conflicting or redundant options
 DETAIL:  FROM cannot be specified together with any other options.
+-- Regex exact-match optimization should use index even when the expression
+-- has COLLATE "default" and the index has a different (but deterministic)
+-- collation OID, because equality is collation-insensitive for deterministic
+-- collations.
+CREATE TABLE regex_idx_test (x text);
+CREATE INDEX ON regex_idx_test (x COLLATE "C");
+SET enable_seqscan = off;
+SET enable_bitmapscan = off;
+EXPLAIN (costs off)
+SELECT * FROM regex_idx_test WHERE x ~ '^(abc)$' COLLATE "default";
+                          QUERY PLAN                          
+--------------------------------------------------------------
+ Index Only Scan using regex_idx_test_x_idx on regex_idx_test
+   Index Cond: (x = 'abc'::text)
+   Filter: (x ~ '^(abc)$'::text)
+(3 rows)
+
+RESET enable_seqscan;
+RESET enable_bitmapscan;
 --
 -- Clean up.  Many of these table names will be re-used if the user is
 -- trying to run any platform-specific collation tests later, so we
 -- must get rid of them.
 --
 DROP SCHEMA collate_tests CASCADE;
-NOTICE:  drop cascades to 20 other objects
+NOTICE:  drop cascades to 21 other objects
 DETAIL:  drop cascades to table collate_test1
 drop cascades to table collate_test_like
 drop cascades to table collate_test2
@@ -795,3 +814,4 @@ drop cascades to collation builtin_c
 drop cascades to collation mycoll2
 drop cascades to table collate_test23
 drop cascades to view collate_on_int
+drop cascades to table regex_idx_test

--- a/src/test/regress/expected/collate.out
+++ b/src/test/regress/expected/collate.out
@@ -782,9 +782,35 @@ SELECT * FROM regex_idx_test WHERE x ~ '^(abc)$' COLLATE "default";
 --------------------------------------------------------------
  Index Only Scan using regex_idx_test_x_idx on regex_idx_test
    Index Cond: (x = 'abc'::text)
-   Filter: (x ~ '^(abc)$'::text)
+(2 rows)
+
+RESET enable_seqscan;
+RESET enable_bitmapscan;
+-- Conversely, when the expression's collation is indeterminate (here a
+-- concatenation of differently-collated columns) but the index pins a
+-- collation, the "=" indexqual must stay lossy so the LIKE recheck still runs.
+-- Otherwise the query would silently resolve the comparison under the index's
+-- collation instead of failing with "could not determine which collation to
+-- use", making the result depend on whether an index scan is chosen.
+CREATE TABLE coll_conflict_idx_test (x text COLLATE "C", y text COLLATE "POSIX");
+INSERT INTO coll_conflict_idx_test VALUES ('a', 'bc');
+CREATE INDEX ON coll_conflict_idx_test ((x || y) COLLATE "C");
+SET enable_seqscan = off;
+SET enable_bitmapscan = off;
+EXPLAIN (costs off)
+SELECT * FROM coll_conflict_idx_test WHERE (x || y) LIKE 'abc';
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Index Scan using coll_conflict_idx_test_x_y_idx on coll_conflict_idx_test
+   Index Cond: ((x || y) = 'abc'::text)
+   Filter: ((x || y) ~~ 'abc'::text)
 (3 rows)
 
+-- must error (rather than silently return the row via the index) so that the
+-- outcome does not depend on the chosen plan
+SELECT * FROM coll_conflict_idx_test WHERE (x || y) LIKE 'abc';
+ERROR:  could not determine which collation to use for LIKE
+HINT:  Use the COLLATE clause to set the collation explicitly.
 RESET enable_seqscan;
 RESET enable_bitmapscan;
 --
@@ -793,7 +819,7 @@ RESET enable_bitmapscan;
 -- must get rid of them.
 --
 DROP SCHEMA collate_tests CASCADE;
-NOTICE:  drop cascades to 21 other objects
+NOTICE:  drop cascades to 22 other objects
 DETAIL:  drop cascades to table collate_test1
 drop cascades to table collate_test_like
 drop cascades to table collate_test2
@@ -815,3 +841,4 @@ drop cascades to collation mycoll2
 drop cascades to table collate_test23
 drop cascades to view collate_on_int
 drop cascades to table regex_idx_test
+drop cascades to table coll_conflict_idx_test

--- a/src/test/regress/expected/regex.out
+++ b/src/test/regress/expected/regex.out
@@ -306,8 +306,7 @@ explain (costs off) select * from pg_proc where proname ~ '^abc$';
 ------------------------------------------------------------
  Index Scan using pg_proc_proname_args_nsp_index on pg_proc
    Index Cond: (proname = 'abc'::text)
-   Filter: (proname ~ '^abc$'::text)
-(3 rows)
+(2 rows)
 
 explain (costs off) select * from pg_proc where proname ~ '^abcd*e';
                               QUERY PLAN                              
@@ -338,8 +337,7 @@ explain (costs off) select * from pg_proc where proname ~ '^(abc)$';
 ------------------------------------------------------------
  Index Scan using pg_proc_proname_args_nsp_index on pg_proc
    Index Cond: (proname = 'abc'::text)
-   Filter: (proname ~ '^(abc)$'::text)
-(3 rows)
+(2 rows)
 
 explain (costs off) select * from pg_proc where proname ~ '^(abc)?d';
                QUERY PLAN               

--- a/src/test/regress/sql/collate.icu.utf8.sql
+++ b/src/test/regress/sql/collate.icu.utf8.sql
@@ -594,6 +594,18 @@ SELECT x FROM test3cs WHERE x LIKE 'a%';
 SELECT x FROM test3cs WHERE x ILIKE 'a%';
 SELECT x FROM test3cs WHERE x SIMILAR TO 'a%';
 SELECT x FROM test3cs WHERE x ~ 'a';
+-- An exact-match regex is converted to an "=" indexqual.  We can use an index
+-- whose collation differs from the expression's as long as the expression's
+-- collation is deterministic, even when the index's collation is
+-- nondeterministic.  Check that we get an index scan rather than a seqscan.
+CREATE INDEX test3cs_ci ON test3cs (x COLLATE case_insensitive);
+SET enable_seqscan = off;
+SET enable_bitmapscan = off;
+EXPLAIN (costs off)
+SELECT x FROM test3cs WHERE x ~ '^(abc)$';
+RESET enable_seqscan;
+RESET enable_bitmapscan;
+DROP INDEX test3cs_ci;
 SET enable_hashagg TO off;
 SELECT x FROM test1cs UNION SELECT x FROM test2cs ORDER BY x;
 SELECT x FROM test2cs UNION SELECT x FROM test1cs ORDER BY x;

--- a/src/test/regress/sql/collate.icu.utf8.sql
+++ b/src/test/regress/sql/collate.icu.utf8.sql
@@ -603,6 +603,12 @@ SET enable_seqscan = off;
 SET enable_bitmapscan = off;
 EXPLAIN (costs off)
 SELECT x FROM test3cs WHERE x ~ '^(abc)$';
+-- When the expression uses the same (nondeterministic) collation as the index,
+-- the "=" indexqual means exactly what the exact-match pattern does, so the
+-- recheck Filter is dropped even though the collation is nondeterministic.
+EXPLAIN (costs off)
+SELECT x FROM test3cs WHERE x COLLATE case_insensitive LIKE 'abc';
+SELECT x FROM test3cs WHERE x COLLATE case_insensitive LIKE 'abc' ORDER BY x;
 RESET enable_seqscan;
 RESET enable_bitmapscan;
 DROP INDEX test3cs_ci;

--- a/src/test/regress/sql/collate.sql
+++ b/src/test/regress/sql/collate.sql
@@ -302,6 +302,19 @@ CREATE COLLATION coll_dup_chk (LC_CTYPE = "POSIX", LOCALE = '');
 -- FROM conflicts with any other option
 CREATE COLLATION coll_dup_chk (FROM = "C", VERSION = "1");
 
+-- Regex exact-match optimization should use index even when the expression
+-- has COLLATE "default" and the index has a different (but deterministic)
+-- collation OID, because equality is collation-insensitive for deterministic
+-- collations.
+CREATE TABLE regex_idx_test (x text);
+CREATE INDEX ON regex_idx_test (x COLLATE "C");
+SET enable_seqscan = off;
+SET enable_bitmapscan = off;
+EXPLAIN (costs off)
+SELECT * FROM regex_idx_test WHERE x ~ '^(abc)$' COLLATE "default";
+RESET enable_seqscan;
+RESET enable_bitmapscan;
+
 --
 -- Clean up.  Many of these table names will be re-used if the user is
 -- trying to run any platform-specific collation tests later, so we

--- a/src/test/regress/sql/collate.sql
+++ b/src/test/regress/sql/collate.sql
@@ -315,6 +315,25 @@ SELECT * FROM regex_idx_test WHERE x ~ '^(abc)$' COLLATE "default";
 RESET enable_seqscan;
 RESET enable_bitmapscan;
 
+-- Conversely, when the expression's collation is indeterminate (here a
+-- concatenation of differently-collated columns) but the index pins a
+-- collation, the "=" indexqual must stay lossy so the LIKE recheck still runs.
+-- Otherwise the query would silently resolve the comparison under the index's
+-- collation instead of failing with "could not determine which collation to
+-- use", making the result depend on whether an index scan is chosen.
+CREATE TABLE coll_conflict_idx_test (x text COLLATE "C", y text COLLATE "POSIX");
+INSERT INTO coll_conflict_idx_test VALUES ('a', 'bc');
+CREATE INDEX ON coll_conflict_idx_test ((x || y) COLLATE "C");
+SET enable_seqscan = off;
+SET enable_bitmapscan = off;
+EXPLAIN (costs off)
+SELECT * FROM coll_conflict_idx_test WHERE (x || y) LIKE 'abc';
+-- must error (rather than silently return the row via the index) so that the
+-- outcome does not depend on the chosen plan
+SELECT * FROM coll_conflict_idx_test WHERE (x || y) LIKE 'abc';
+RESET enable_seqscan;
+RESET enable_bitmapscan;
+
 --
 -- Clean up.  Many of these table names will be re-used if the user is
 -- trying to run any platform-specific collation tests later, so we


### PR DESCRIPTION
- **Fix LIKE/regex optimization for indexscan with exact-match pattern**
- **Treat exact-match LIKE/regex pattern as non-lossy indexqual when possible**
