### PR TITLE
pure prefix non lossy

### DIFF
--- a/src/backend/regex/regprefix.c
+++ b/src/backend/regex/regprefix.c
@@ -20,7 +20,7 @@
  * forward declarations
  */
 static int	findprefix(struct cnfa *cnfa, struct colormap *cm,
-					   chr *string, size_t *slength);
+					   chr *string, size_t *slength, bool *matchall);
 
 
 /*
@@ -41,11 +41,19 @@ static int	findprefix(struct cnfa *cnfa, struct colormap *cm,
  * the reported prefix or exact-match string do not satisfy the regex.  But
  * it should never be the case that a string satisfying the regex does not
  * match the reported prefix or exact-match string.
+ *
+ * If matchall is not NULL, *matchall is set to true when the regex is
+ * equivalent to a pure prefix test, i.e. it matches exactly the strings that
+ * begin with the reported prefix (with REG_PREFIX result).  It is always set
+ * to false for the REG_EXACT and failure cases.  Unlike the prefix itself,
+ * this is computed exactly: *matchall is never set to true unless every string
+ * beginning with the prefix does satisfy the regex.
  */
 int
 pg_regprefix(regex_t *re,
 			 chr **string,
-			 size_t *slength)
+			 size_t *slength,
+			 bool *matchall)
 {
 	struct guts *g;
 	struct cnfa *cnfa;
@@ -56,6 +64,8 @@ pg_regprefix(regex_t *re,
 		return REG_INVARG;
 	*string = NULL;				/* initialize for failure cases */
 	*slength = 0;
+	if (matchall != NULL)
+		*matchall = false;
 	if (re == NULL || re->re_magic != REMAGIC)
 		return REG_INVARG;
 	if (re->re_csize != sizeof(chr))
@@ -91,7 +101,7 @@ pg_regprefix(regex_t *re,
 		return REG_ESPACE;
 
 	/* do it */
-	st = findprefix(cnfa, &g->cmap, *string, slength);
+	st = findprefix(cnfa, &g->cmap, *string, slength, matchall);
 
 	assert(*slength <= cnfa->nstates);
 
@@ -116,7 +126,8 @@ static int						/* regprefix return code */
 findprefix(struct cnfa *cnfa,
 		   struct colormap *cm,
 		   chr *string,
-		   size_t *slength)
+		   size_t *slength,
+		   bool *matchall)
 {
 	int			st;
 	int			nextst;
@@ -255,6 +266,34 @@ findprefix(struct cnfa *cnfa,
 	}
 	if (nextst == cnfa->post)
 		return REG_EXACT;
+
+	/*
+	 * Check for a "matchall suffix": from state st, is every possible
+	 * continuation of the string accepted?  That's the case when st has both
+	 * a RAINBOW arc to the "post" state (so consuming any one more character
+	 * completes a match) and an EOS arc to "post" (so the string may also end
+	 * here).  Together these mean that any string with the identified prefix
+	 * satisfies the regex, i.e. the regex is equivalent to a pure prefix
+	 * test. (This is not fooled by additional arcs, including LACON
+	 * constraints: the RAINBOW-to-post arc is an unconditional accepting
+	 * path, so no string with the prefix can fail to match.)
+	 */
+	if (matchall != NULL && *slength > 0)
+	{
+		bool		rainbow_to_post = false;
+		bool		eos_to_post = false;
+
+		for (ca = cnfa->states[st]; ca->co != COLORLESS; ca++)
+		{
+			if (ca->to != cnfa->post)
+				continue;
+			if (ca->co == RAINBOW)
+				rainbow_to_post = true;
+			else if (ca->co == cnfa->eos[0] || ca->co == cnfa->eos[1])
+				eos_to_post = true;
+		}
+		*matchall = (rainbow_to_post && eos_to_post);
+	}
 
 	/*
 	 * Otherwise, if we were unable to identify any prefix characters, say

--- a/src/backend/utils/adt/like_support.c
+++ b/src/backend/utils/adt/like_support.c
@@ -79,7 +79,8 @@ static List *match_pattern_prefix(Node *leftop,
 								  Pattern_Type ptype,
 								  Oid expr_coll,
 								  Oid opfamily,
-								  Oid indexcollation);
+								  Oid indexcollation,
+								  bool *lossy);
 static double patternsel_common(PlannerInfo *root,
 								Oid oprid,
 								Oid opfuncid,
@@ -215,7 +216,8 @@ like_regex_support(Node *rawreq, Pattern_Type ptype)
 									 ptype,
 									 clause->inputcollid,
 									 req->opfamily,
-									 req->indexcollation);
+									 req->indexcollation,
+									 &req->lossy);
 		}
 		else if (is_funcclause(req->node))	/* be paranoid */
 		{
@@ -228,7 +230,8 @@ like_regex_support(Node *rawreq, Pattern_Type ptype)
 									 ptype,
 									 clause->inputcollid,
 									 req->opfamily,
-									 req->indexcollation);
+									 req->indexcollation,
+									 &req->lossy);
 		}
 	}
 
@@ -245,7 +248,8 @@ match_pattern_prefix(Node *leftop,
 					 Pattern_Type ptype,
 					 Oid expr_coll,
 					 Oid opfamily,
-					 Oid indexcollation)
+					 Oid indexcollation,
+					 bool *lossy)
 {
 	List	   *result;
 	Const	   *patt;
@@ -391,8 +395,8 @@ match_pattern_prefix(Node *leftop,
 	 * It doesn't matter whether the index collation is deterministic or not:
 	 * if it's deterministic it agrees on equality with the expression
 	 * collation, and if it's nondeterministic the "=" indexqual merely treats
-	 * a superset of values as equal.  The latter is fine because the
-	 * indexqual is lossy (the original pattern is rechecked), so the recheck
+	 * a superset of values as equal.  The latter is fine because we keep the
+	 * indexqual as lossy (the original pattern is rechecked), so the recheck
 	 * filters out the rows where the index collation disagrees with the
 	 * expression collation.  A nondeterministic expression collation, on the
 	 * other hand, is only safe when the index uses that exact same collation,
@@ -405,6 +409,21 @@ match_pattern_prefix(Node *leftop,
 			return NIL;
 		if (indexcollation != expr_coll && NONDETERMINISTIC(expr_coll))
 			return NIL;
+
+		/*
+		 * The "=" indexqual is normally treated as lossy (the original
+		 * pattern is rechecked) because "=" can match rows that the pattern
+		 * does not. But when the type is not blank-padded and both collations
+		 * are deterministic, "=" is exactly bytewise equality, i.e. precisely
+		 * the exact-match pattern, so the recheck can be skipped.  bpchar is
+		 * excluded because its "=" ignores trailing blanks, and a
+		 * nondeterministic collation is excluded because then "=" matches a
+		 * superset of the pattern; both of those genuinely need the recheck.
+		 */
+		if (ldatatype != BPCHAROID &&
+			!NONDETERMINISTIC(indexcollation) && !NONDETERMINISTIC(expr_coll))
+			*lossy = false;
+
 		expr = make_opclause(eqopr, BOOLOID, false,
 							 (Expr *) leftop, (Expr *) prefix,
 							 InvalidOid, indexcollation);

--- a/src/backend/utils/adt/like_support.c
+++ b/src/backend/utils/adt/like_support.c
@@ -69,6 +69,10 @@ typedef enum
 	Pattern_Prefix_None, Pattern_Prefix_Partial, Pattern_Prefix_Exact,
 } Pattern_Prefix_Status;
 
+/* non-collatable comparisons, eg for bytea, are always deterministic */
+#define NONDETERMINISTIC(coll) \
+	(OidIsValid(coll) && !get_collation_isdeterministic(coll))
+
 static Node *like_regex_support(Node *rawreq, Pattern_Type ptype);
 static List *match_pattern_prefix(Node *leftop,
 								  Node *rightop,
@@ -381,12 +385,25 @@ match_pattern_prefix(Node *leftop,
 	 * us to not be concerned with specific opclasses (except for the legacy
 	 * "pattern" cases); any index that correctly implements the operators
 	 * will work.
+	 *
+	 * Also, we can use an index whose collation differs from the
+	 * expression's, so long as the expression's collation is deterministic.
+	 * It doesn't matter whether the index collation is deterministic or not:
+	 * if it's deterministic it agrees on equality with the expression
+	 * collation, and if it's nondeterministic the "=" indexqual merely treats
+	 * a superset of values as equal.  The latter is fine because the
+	 * indexqual is lossy (the original pattern is rechecked), so the recheck
+	 * filters out the rows where the index collation disagrees with the
+	 * expression collation.  A nondeterministic expression collation, on the
+	 * other hand, is only safe when the index uses that exact same collation,
+	 * since otherwise the indexqual could omit matching rows.  Otherwise,
+	 * fail quietly.
 	 */
 	if (pstatus == Pattern_Prefix_Exact)
 	{
 		if (!op_in_opfamily(eqopr, opfamily))
 			return NIL;
-		if (indexcollation != expr_coll)
+		if (indexcollation != expr_coll && NONDETERMINISTIC(expr_coll))
 			return NIL;
 		expr = make_opclause(eqopr, BOOLOID, false,
 							 (Expr *) leftop, (Expr *) prefix,
@@ -400,10 +417,8 @@ match_pattern_prefix(Node *leftop,
 	 * expression collation is nondeterministic.  The optimized equality or
 	 * prefix tests use bytewise comparisons, which is not consistent with
 	 * nondeterministic collations.
-	 *
-	 * expr_coll is not set for a non-collation-aware data type such as bytea.
 	 */
-	if (expr_coll && !get_collation_isdeterministic(expr_coll))
+	if (NONDETERMINISTIC(expr_coll))
 		return NIL;
 
 	/*

--- a/src/backend/utils/adt/like_support.c
+++ b/src/backend/utils/adt/like_support.c
@@ -93,7 +93,8 @@ static Pattern_Prefix_Status pattern_fixed_prefix(Const *patt,
 												  Pattern_Type ptype,
 												  Oid collation,
 												  Const **prefix,
-												  Selectivity *rest_selec);
+												  Selectivity *rest_selec,
+												  bool *pure_prefix);
 static Selectivity prefix_selectivity(PlannerInfo *root,
 									  VariableStatData *vardata,
 									  Oid eqopr, Oid ltopr, Oid geopr,
@@ -255,6 +256,7 @@ match_pattern_prefix(Node *leftop,
 	Const	   *patt;
 	Const	   *prefix;
 	Pattern_Prefix_Status pstatus;
+	bool		pure_prefix = false;
 	Oid			ldatatype;
 	Oid			rdatatype;
 	Oid			eqopr;
@@ -282,7 +284,7 @@ match_pattern_prefix(Node *leftop,
 	 * Try to extract a fixed prefix from the pattern.
 	 */
 	pstatus = pattern_fixed_prefix(patt, ptype, expr_coll,
-								   &prefix, NULL);
+								   &prefix, NULL, &pure_prefix);
 
 	/* fail if no fixed prefix */
 	if (pstatus == Pattern_Prefix_None)
@@ -447,6 +449,17 @@ match_pattern_prefix(Node *leftop,
 	 */
 	if (OidIsValid(preopr) && op_in_opfamily(preopr, opfamily))
 	{
+		/*
+		 * A pure-prefix pattern means exactly "value starts with <prefix>",
+		 * which is precisely what the prefix operator tests, so the recheck
+		 * can be skipped.  As with the "=" case above, a nondeterministic
+		 * index collation is excluded: the operator would then match a
+		 * superset and still needs the recheck.
+		 */
+		if (pure_prefix &&
+			!NONDETERMINISTIC(indexcollation) && !NONDETERMINISTIC(expr_coll))
+			*lossy = false;
+
 		expr = make_opclause(preopr, BOOLOID, false,
 							 (Expr *) leftop, (Expr *) prefix,
 							 InvalidOid, indexcollation);
@@ -652,7 +665,7 @@ patternsel_common(PlannerInfo *root,
 	 */
 	patt = (Const *) other;
 	pstatus = pattern_fixed_prefix(patt, ptype, collation,
-								   &prefix, &rest_selec);
+								   &prefix, &rest_selec, NULL);
 
 	/*
 	 * If necessary, coerce the prefix constant to the right type.  The only
@@ -1019,7 +1032,7 @@ icnlikejoinsel(PG_FUNCTION_ARGS)
 
 static Pattern_Prefix_Status
 like_fixed_prefix(Const *patt_const, Const **prefix_const,
-				  Selectivity *rest_selec)
+				  Selectivity *rest_selec, bool *pure_prefix)
 {
 	char	   *match;
 	char	   *patt;
@@ -1075,6 +1088,26 @@ like_fixed_prefix(Const *patt_const, Const **prefix_const,
 
 	if (rest_selec != NULL)
 		*rest_selec = like_selectivity(&patt[pos], pattlen - pos, false);
+
+	/*
+	 * The pattern is a "pure prefix" -- equivalent to "value starts with
+	 * <prefix>" -- when everything after the extracted prefix consists of '%'
+	 * wildcards.  A '_', or a literal (including an escaped '%') after the
+	 * prefix, would constrain the value beyond the prefix, so those are not
+	 * pure prefixes.  This lets the caller emit a non-lossy prefix indexqual.
+	 */
+	if (pure_prefix != NULL)
+	{
+		*pure_prefix = (pos < pattlen);
+		for (int i = pos; i < pattlen; i++)
+		{
+			if (patt[i] != '%')
+			{
+				*pure_prefix = false;
+				break;
+			}
+		}
+	}
 
 	pfree(patt);
 	pfree(match);
@@ -1197,7 +1230,8 @@ like_fixed_prefix_ci(Const *patt_const, Oid collation, Const **prefix_const,
 
 static Pattern_Prefix_Status
 regex_fixed_prefix(Const *patt_const, bool case_insensitive, Oid collation,
-				   Const **prefix_const, Selectivity *rest_selec)
+				   Const **prefix_const, Selectivity *rest_selec,
+				   bool *pure_prefix)
 {
 	Oid			typeid = patt_const->consttype;
 	char	   *prefix;
@@ -1216,7 +1250,7 @@ regex_fixed_prefix(Const *patt_const, bool case_insensitive, Oid collation,
 	/* Use the regexp machinery to extract the prefix, if any */
 	prefix = regexp_fixed_prefix(DatumGetTextPP(patt_const->constvalue),
 								 case_insensitive, collation,
-								 &exact);
+								 &exact, pure_prefix);
 
 	if (prefix == NULL)
 	{
@@ -1265,14 +1299,22 @@ regex_fixed_prefix(Const *patt_const, bool case_insensitive, Oid collation,
 
 static Pattern_Prefix_Status
 pattern_fixed_prefix(Const *patt, Pattern_Type ptype, Oid collation,
-					 Const **prefix, Selectivity *rest_selec)
+					 Const **prefix, Selectivity *rest_selec, bool *pure_prefix)
 {
 	Pattern_Prefix_Status result;
+
+	/*
+	 * Default to "not a pure prefix".  Only LIKE and the prefix operator can
+	 * currently prove this; the regex machinery can't tell an unconstrained
+	 * tail (e.g. "^abc") from a constrained one (e.g. "^abc[0-9]").
+	 */
+	if (pure_prefix != NULL)
+		*pure_prefix = false;
 
 	switch (ptype)
 	{
 		case Pattern_Type_Like:
-			result = like_fixed_prefix(patt, prefix, rest_selec);
+			result = like_fixed_prefix(patt, prefix, rest_selec, pure_prefix);
 			break;
 		case Pattern_Type_Like_IC:
 			result = like_fixed_prefix_ci(patt, collation, prefix,
@@ -1280,15 +1322,18 @@ pattern_fixed_prefix(Const *patt, Pattern_Type ptype, Oid collation,
 			break;
 		case Pattern_Type_Regex:
 			result = regex_fixed_prefix(patt, false, collation,
-										prefix, rest_selec);
+										prefix, rest_selec, pure_prefix);
 			break;
 		case Pattern_Type_Regex_IC:
 			result = regex_fixed_prefix(patt, true, collation,
-										prefix, rest_selec);
+										prefix, rest_selec, pure_prefix);
 			break;
 		case Pattern_Type_Prefix:
 			/* Prefix type work is trivial.  */
 			result = Pattern_Prefix_Partial;
+			/* A prefix operator is by definition a pure prefix match. */
+			if (pure_prefix != NULL)
+				*pure_prefix = true;
 			*prefix = makeConst(patt->consttype,
 								patt->consttypmod,
 								patt->constcollid,

--- a/src/backend/utils/adt/regexp.c
+++ b/src/backend/utils/adt/regexp.c
@@ -2020,21 +2020,27 @@ regexp_substr_no_subexpr(PG_FUNCTION_ARGS)
  *
  * The result is NULL if there is no fixed prefix, else a palloc'd string.
  * If it is an exact match, not just a prefix, *exact is returned as true.
+ * If pure_prefix is not NULL, *pure_prefix is set to true when the regexp
+ * matches exactly the strings that begin with the prefix (so that a prefix
+ * test is an exact equivalent of the regexp, not merely a superset).
  */
 char *
 regexp_fixed_prefix(text *text_re, bool case_insensitive, Oid collation,
-					bool *exact)
+					bool *exact, bool *pure_prefix)
 {
 	char	   *result;
 	regex_t    *re;
 	int			cflags;
 	int			re_result;
+	bool		matchall;
 	pg_wchar   *str;
 	size_t		slen;
 	size_t		maxlen;
 	char		errMsg[100];
 
 	*exact = false;				/* default result */
+	if (pure_prefix != NULL)
+		*pure_prefix = false;
 
 	/* Compile RE */
 	cflags = REG_ADVANCED;
@@ -2044,7 +2050,9 @@ regexp_fixed_prefix(text *text_re, bool case_insensitive, Oid collation,
 	re = RE_compile_and_cache(text_re, cflags | REG_NOSUB, collation);
 
 	/* Examine it to see if there's a fixed prefix */
-	re_result = pg_regprefix(re, &str, &slen);
+	re_result = pg_regprefix(re, &str, &slen, &matchall);
+	if (pure_prefix != NULL)
+		*pure_prefix = matchall;
 
 	switch (re_result)
 	{

--- a/src/include/regex/regex.h
+++ b/src/include/regex/regex.h
@@ -258,7 +258,8 @@ extern int	pg_regcomp(regex_t *re, const pg_wchar *string, size_t len,
 extern int	pg_regexec(regex_t *re, const pg_wchar *string, size_t len,
 					   size_t search_start, rm_detail_t *details,
 					   size_t nmatch, regmatch_t pmatch[], int flags);
-extern int	pg_regprefix(regex_t *re, pg_wchar **string, size_t *slength);
+extern int	pg_regprefix(regex_t *re, pg_wchar **string, size_t *slength,
+						 bool *matchall);
 extern void pg_regfree(regex_t *re);
 extern size_t pg_regerror(int errcode, const regex_t *preg, char *errbuf,
 						  size_t errbuf_size);

--- a/src/include/utils/builtins.h
+++ b/src/include/utils/builtins.h
@@ -74,7 +74,7 @@ extern int	oid_cmp(const void *p1, const void *p2);
 
 /* regexp.c */
 extern char *regexp_fixed_prefix(text *text_re, bool case_insensitive,
-								 Oid collation, bool *exact);
+								 Oid collation, bool *exact, bool *pure_prefix);
 
 /* ruleutils.c */
 extern PGDLLIMPORT bool quote_all_identifiers;

--- a/src/test/regress/expected/collate.icu.utf8.out
+++ b/src/test/regress/expected/collate.icu.utf8.out
@@ -1561,6 +1561,25 @@ SELECT x FROM test3cs WHERE x ~ 'a';
  abc
 (1 row)
 
+-- An exact-match regex is converted to an "=" indexqual.  We can use an index
+-- whose collation differs from the expression's as long as the expression's
+-- collation is deterministic, even when the index's collation is
+-- nondeterministic.  Check that we get an index scan rather than a seqscan.
+CREATE INDEX test3cs_ci ON test3cs (x COLLATE case_insensitive);
+SET enable_seqscan = off;
+SET enable_bitmapscan = off;
+EXPLAIN (costs off)
+SELECT x FROM test3cs WHERE x ~ '^(abc)$';
+                 QUERY PLAN                  
+---------------------------------------------
+ Index Only Scan using test3cs_ci on test3cs
+   Index Cond: (x = 'abc'::text)
+   Filter: (x ~ '^(abc)$'::text)
+(3 rows)
+
+RESET enable_seqscan;
+RESET enable_bitmapscan;
+DROP INDEX test3cs_ci;
 SET enable_hashagg TO off;
 SELECT x FROM test1cs UNION SELECT x FROM test2cs ORDER BY x;
   x  

--- a/src/test/regress/expected/collate.out
+++ b/src/test/regress/expected/collate.out
@@ -768,13 +768,32 @@ DETAIL:  LOCALE cannot be specified together with LC_COLLATE or LC_CTYPE.
 CREATE COLLATION coll_dup_chk (FROM = "C", VERSION = "1");
 ERROR:  conflicting or redundant options
 DETAIL:  FROM cannot be specified together with any other options.
+-- Regex exact-match optimization should use index even when the expression
+-- has COLLATE "default" and the index has a different (but deterministic)
+-- collation OID, because equality is collation-insensitive for deterministic
+-- collations.
+CREATE TABLE regex_idx_test (x text);
+CREATE INDEX ON regex_idx_test (x COLLATE "C");
+SET enable_seqscan = off;
+SET enable_bitmapscan = off;
+EXPLAIN (costs off)
+SELECT * FROM regex_idx_test WHERE x ~ '^(abc)$' COLLATE "default";
+                          QUERY PLAN                          
+--------------------------------------------------------------
+ Index Only Scan using regex_idx_test_x_idx on regex_idx_test
+   Index Cond: (x = 'abc'::text)
+   Filter: (x ~ '^(abc)$'::text)
+(3 rows)
+
+RESET enable_seqscan;
+RESET enable_bitmapscan;
 --
 -- Clean up.  Many of these table names will be re-used if the user is
 -- trying to run any platform-specific collation tests later, so we
 -- must get rid of them.
 --
 DROP SCHEMA collate_tests CASCADE;
-NOTICE:  drop cascades to 20 other objects
+NOTICE:  drop cascades to 21 other objects
 DETAIL:  drop cascades to table collate_test1
 drop cascades to table collate_test_like
 drop cascades to table collate_test2
@@ -795,3 +814,4 @@ drop cascades to collation builtin_c
 drop cascades to collation mycoll2
 drop cascades to table collate_test23
 drop cascades to view collate_on_int
+drop cascades to table regex_idx_test

--- a/src/test/regress/expected/collate.out
+++ b/src/test/regress/expected/collate.out
@@ -782,8 +782,7 @@ SELECT * FROM regex_idx_test WHERE x ~ '^(abc)$' COLLATE "default";
 --------------------------------------------------------------
  Index Only Scan using regex_idx_test_x_idx on regex_idx_test
    Index Cond: (x = 'abc'::text)
-   Filter: (x ~ '^(abc)$'::text)
-(3 rows)
+(2 rows)
 
 RESET enable_seqscan;
 RESET enable_bitmapscan;

--- a/src/test/regress/expected/create_index_spgist.out
+++ b/src/test/regress/expected/create_index_spgist.out
@@ -817,10 +817,79 @@ SELECT count(*) FROM radix_text_tbl WHERE starts_with(t, 'Worth');
  Aggregate
    ->  Index Only Scan using sp_radix_ind on radix_text_tbl
          Index Cond: (t ^@ 'Worth'::text)
-         Filter: starts_with(t, 'Worth'::text)
-(4 rows)
+(3 rows)
 
 SELECT count(*) FROM radix_text_tbl WHERE starts_with(t, 'Worth');
+ count 
+-------
+     2
+(1 row)
+
+-- A pure-prefix LIKE is converted to a prefix (^@) indexqual.  Since that is
+-- an exact equivalent of the pattern, the plan should have no recheck Filter.
+EXPLAIN (COSTS OFF)
+SELECT count(*) FROM radix_text_tbl WHERE t LIKE 'Worth%';
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Aggregate
+   ->  Index Only Scan using sp_radix_ind on radix_text_tbl
+         Index Cond: (t ^@ 'Worth'::text)
+(3 rows)
+
+SELECT count(*) FROM radix_text_tbl WHERE t LIKE 'Worth%';
+ count 
+-------
+     2
+(1 row)
+
+-- A LIKE with more pattern after the prefix is not a pure prefix, so the
+-- prefix indexqual is lossy and the recheck Filter must remain.
+EXPLAIN (COSTS OFF)
+SELECT count(*) FROM radix_text_tbl WHERE t LIKE 'Worth%St%';
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Aggregate
+   ->  Index Only Scan using sp_radix_ind on radix_text_tbl
+         Index Cond: (t ^@ 'Worth'::text)
+         Filter: (t ~~ 'Worth%St%'::text)
+(4 rows)
+
+SELECT count(*) FROM radix_text_tbl WHERE t LIKE 'Worth%St%';
+ count 
+-------
+     2
+(1 row)
+
+-- The same holds for a regex whose whole match is a fixed prefix: '^Worth'
+-- accepts any suffix, so it is a pure prefix and needs no recheck Filter.
+EXPLAIN (COSTS OFF)
+SELECT count(*) FROM radix_text_tbl WHERE t ~ '^Worth';
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Aggregate
+   ->  Index Only Scan using sp_radix_ind on radix_text_tbl
+         Index Cond: (t ^@ 'Worth'::text)
+(3 rows)
+
+SELECT count(*) FROM radix_text_tbl WHERE t ~ '^Worth';
+ count 
+-------
+     2
+(1 row)
+
+-- But a regex that constrains the string after the prefix ('^Worth.*St') is
+-- not a pure prefix, so the prefix indexqual stays lossy.
+EXPLAIN (COSTS OFF)
+SELECT count(*) FROM radix_text_tbl WHERE t ~ '^Worth.*St';
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Aggregate
+   ->  Index Only Scan using sp_radix_ind on radix_text_tbl
+         Index Cond: (t ^@ 'Worth'::text)
+         Filter: (t ~ '^Worth.*St'::text)
+(4 rows)
+
+SELECT count(*) FROM radix_text_tbl WHERE t ~ '^Worth.*St';
  count 
 -------
      2

--- a/src/test/regress/expected/regex.out
+++ b/src/test/regress/expected/regex.out
@@ -306,8 +306,7 @@ explain (costs off) select * from pg_proc where proname ~ '^abc$';
 ------------------------------------------------------------
  Index Scan using pg_proc_proname_args_nsp_index on pg_proc
    Index Cond: (proname = 'abc'::text)
-   Filter: (proname ~ '^abc$'::text)
-(3 rows)
+(2 rows)
 
 explain (costs off) select * from pg_proc where proname ~ '^abcd*e';
                               QUERY PLAN                              
@@ -338,8 +337,7 @@ explain (costs off) select * from pg_proc where proname ~ '^(abc)$';
 ------------------------------------------------------------
  Index Scan using pg_proc_proname_args_nsp_index on pg_proc
    Index Cond: (proname = 'abc'::text)
-   Filter: (proname ~ '^(abc)$'::text)
-(3 rows)
+(2 rows)
 
 explain (costs off) select * from pg_proc where proname ~ '^(abc)?d';
                QUERY PLAN               

--- a/src/test/regress/sql/collate.icu.utf8.sql
+++ b/src/test/regress/sql/collate.icu.utf8.sql
@@ -594,6 +594,18 @@ SELECT x FROM test3cs WHERE x LIKE 'a%';
 SELECT x FROM test3cs WHERE x ILIKE 'a%';
 SELECT x FROM test3cs WHERE x SIMILAR TO 'a%';
 SELECT x FROM test3cs WHERE x ~ 'a';
+-- An exact-match regex is converted to an "=" indexqual.  We can use an index
+-- whose collation differs from the expression's as long as the expression's
+-- collation is deterministic, even when the index's collation is
+-- nondeterministic.  Check that we get an index scan rather than a seqscan.
+CREATE INDEX test3cs_ci ON test3cs (x COLLATE case_insensitive);
+SET enable_seqscan = off;
+SET enable_bitmapscan = off;
+EXPLAIN (costs off)
+SELECT x FROM test3cs WHERE x ~ '^(abc)$';
+RESET enable_seqscan;
+RESET enable_bitmapscan;
+DROP INDEX test3cs_ci;
 SET enable_hashagg TO off;
 SELECT x FROM test1cs UNION SELECT x FROM test2cs ORDER BY x;
 SELECT x FROM test2cs UNION SELECT x FROM test1cs ORDER BY x;

--- a/src/test/regress/sql/collate.sql
+++ b/src/test/regress/sql/collate.sql
@@ -302,6 +302,19 @@ CREATE COLLATION coll_dup_chk (LC_CTYPE = "POSIX", LOCALE = '');
 -- FROM conflicts with any other option
 CREATE COLLATION coll_dup_chk (FROM = "C", VERSION = "1");
 
+-- Regex exact-match optimization should use index even when the expression
+-- has COLLATE "default" and the index has a different (but deterministic)
+-- collation OID, because equality is collation-insensitive for deterministic
+-- collations.
+CREATE TABLE regex_idx_test (x text);
+CREATE INDEX ON regex_idx_test (x COLLATE "C");
+SET enable_seqscan = off;
+SET enable_bitmapscan = off;
+EXPLAIN (costs off)
+SELECT * FROM regex_idx_test WHERE x ~ '^(abc)$' COLLATE "default";
+RESET enable_seqscan;
+RESET enable_bitmapscan;
+
 --
 -- Clean up.  Many of these table names will be re-used if the user is
 -- trying to run any platform-specific collation tests later, so we

--- a/src/test/regress/sql/create_index_spgist.sql
+++ b/src/test/regress/sql/create_index_spgist.sql
@@ -299,6 +299,30 @@ EXPLAIN (COSTS OFF)
 SELECT count(*) FROM radix_text_tbl WHERE starts_with(t, 'Worth');
 SELECT count(*) FROM radix_text_tbl WHERE starts_with(t, 'Worth');
 
+-- A pure-prefix LIKE is converted to a prefix (^@) indexqual.  Since that is
+-- an exact equivalent of the pattern, the plan should have no recheck Filter.
+EXPLAIN (COSTS OFF)
+SELECT count(*) FROM radix_text_tbl WHERE t LIKE 'Worth%';
+SELECT count(*) FROM radix_text_tbl WHERE t LIKE 'Worth%';
+
+-- A LIKE with more pattern after the prefix is not a pure prefix, so the
+-- prefix indexqual is lossy and the recheck Filter must remain.
+EXPLAIN (COSTS OFF)
+SELECT count(*) FROM radix_text_tbl WHERE t LIKE 'Worth%St%';
+SELECT count(*) FROM radix_text_tbl WHERE t LIKE 'Worth%St%';
+
+-- The same holds for a regex whose whole match is a fixed prefix: '^Worth'
+-- accepts any suffix, so it is a pure prefix and needs no recheck Filter.
+EXPLAIN (COSTS OFF)
+SELECT count(*) FROM radix_text_tbl WHERE t ~ '^Worth';
+SELECT count(*) FROM radix_text_tbl WHERE t ~ '^Worth';
+
+-- But a regex that constrains the string after the prefix ('^Worth.*St') is
+-- not a pure prefix, so the prefix indexqual stays lossy.
+EXPLAIN (COSTS OFF)
+SELECT count(*) FROM radix_text_tbl WHERE t ~ '^Worth.*St';
+SELECT count(*) FROM radix_text_tbl WHERE t ~ '^Worth.*St';
+
 -- Now check the results from bitmap indexscan
 SET enable_seqscan = OFF;
 SET enable_indexscan = OFF;


### PR DESCRIPTION
- **Fix LIKE/regex optimization for indexscan with exact-match pattern**
- **Treat exact-match LIKE/regex pattern as non-lossy indexqual**
- **Add support for pure-prefix non-lossy index scans**
