### PR TITLE
send parameterstatus while idle

### DIFF
--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -148,7 +148,7 @@ static bool xact_started = false;
  * as opposed to any random read from client that might happen within
  * commands like COPY FROM STDIN.
  */
-static bool DoingCommandRead = false;
+bool		DoingCommandRead = false;
 
 /*
  * Flags to implement skip-till-Sync-after-error behavior for messages of

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -528,6 +528,22 @@ ProcessClientReadInterrupt(bool blocked)
 		/* Process notify interrupts, if any */
 		if (notifyInterruptPending)
 			ProcessNotifyInterrupt(true);
+
+		/*
+		 * Apply a pending configuration reload here, while we sit idle
+		 * waiting for a command, rather than deferring it until the next
+		 * command.  This changes GUC_REPORT variables, and
+		 * set_config_option() notices that no query is running (see
+		 * DoingCommandRead) and transmits the resulting ParameterStatus
+		 * messages right away.  So a SIGHUP that changes a reportable setting
+		 * reaches an otherwise-idle client promptly, instead of only once the
+		 * client happens to issue its next query.
+		 */
+		if (ConfigReloadPending)
+		{
+			ConfigReloadPending = false;
+			ProcessConfigFile(PGC_SIGHUP);
+		}
 	}
 	else if (ProcDiePending)
 	{

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -36,6 +36,7 @@
 #include "catalog/pg_parameter_acl.h"
 #include "catalog/pg_type.h"
 #include "guc_internal.h"
+#include "libpq/libpq.h"
 #include "libpq/pqformat.h"
 #include "libpq/protocol.h"
 #include "miscadmin.h"
@@ -4167,11 +4168,38 @@ set_config_with_handle(const char *name, config_handle *handle,
 			}
 	}
 
-	if (changeVal && (record->flags & GUC_REPORT) &&
-		!(record->status & GUC_NEEDS_REPORT))
+	if (changeVal && (record->flags & GUC_REPORT))
 	{
-		record->status |= GUC_NEEDS_REPORT;
-		slist_push_head(&guc_report_list, &record->report_link);
+		/*
+		 * Normally we don't transmit the ParameterStatus right away; we
+		 * merely flag the variable so that ReportChangedGUCOptions() reports
+		 * it once, just before we next become ready for a query.  That
+		 * batching keeps a value that changes repeatedly within a query (e.g.
+		 * via function SET clauses) from generating a flurry of messages.
+		 *
+		 * That rationale only holds while a query is running.  When we're
+		 * sitting idle waiting for the next command there is nothing to
+		 * coalesce, and deferring until the client's next query could mean
+		 * the client never hears about the change.  So in that case report it
+		 * immediately and flush, which lets an idle client (e.g. a connection
+		 * pool) learn about a change such as a reloaded configuration setting
+		 * without having to issue a query first.
+		 */
+		if (reporting_enabled && DoingCommandRead)
+		{
+			if (record->status & GUC_NEEDS_REPORT)
+			{
+				record->status &= ~GUC_NEEDS_REPORT;
+				slist_delete(&guc_report_list, &record->report_link);
+			}
+			ReportGUCOption(record);
+			pq_flush();
+		}
+		else if (!(record->status & GUC_NEEDS_REPORT))
+		{
+			record->status |= GUC_NEEDS_REPORT;
+			slist_push_head(&guc_report_list, &record->report_link);
+		}
 	}
 
 	return changeVal ? 1 : -1;

--- a/src/include/tcop/tcopprot.h
+++ b/src/include/tcop/tcopprot.h
@@ -23,6 +23,7 @@
 typedef struct ExplainState ExplainState;	/* defined in explain_state.h */
 
 extern PGDLLIMPORT CommandDest whereToSendOutput;
+extern PGDLLIMPORT bool DoingCommandRead;
 extern PGDLLIMPORT const char *debug_query_string;
 extern PGDLLIMPORT int PostAuthDelay;
 extern PGDLLIMPORT int client_connection_check_interval;

--- a/src/test/modules/libpq_pipeline/libpq_pipeline.c
+++ b/src/test/modules/libpq_pipeline/libpq_pipeline.c
@@ -2100,6 +2100,81 @@ process_result(PGconn *conn, PGresult *res, int results, int numsent)
 	return got_error;
 }
 
+/*
+ * Verify that a GUC_REPORT setting changed by a configuration reload is
+ * reported to a connection that is sitting idle, without that connection
+ * having to issue a query first.  This exercises the mechanism whereby
+ * set_config_option() transmits a ParameterStatus immediately while no query
+ * is running (see ProcessClientReadInterrupt()).
+ */
+static void
+test_idle_config_report(PGconn *conn)
+{
+	PGconn	   *otherConn;
+	PGresult   *res;
+	const char *val;
+	int			i;
+
+	fprintf(stderr, "test idle config report... ");
+
+	otherConn = copy_connection(conn);
+	Assert(PQstatus(otherConn) == CONNECTION_OK);
+
+	/* Drain startup traffic and confirm the setting isn't already iso_8601. */
+	if (!PQconsumeInput(conn))
+		pg_fatal("PQconsumeInput failed: %s", PQerrorMessage(conn));
+	(void) PQisBusy(conn);
+	val = PQparameterStatus(conn, "IntervalStyle");
+	if (val && strcmp(val, "iso_8601") == 0)
+		pg_fatal("IntervalStyle already iso_8601 before reload");
+
+	/* Change a reportable setting in the config file and reload it. */
+	res = PQexec(otherConn, "ALTER SYSTEM SET intervalstyle = iso_8601");
+	if (PQresultStatus(res) != PGRES_COMMAND_OK)
+		pg_fatal("ALTER SYSTEM failed: %s", PQerrorMessage(otherConn));
+	PQclear(res);
+	res = PQexec(otherConn, "SELECT pg_reload_conf()");
+	if (PQresultStatus(res) != PGRES_TUPLES_OK)
+		pg_fatal("pg_reload_conf() failed: %s", PQerrorMessage(otherConn));
+	PQclear(res);
+
+	/*
+	 * conn is idle and never issues a query, yet it must still be told the
+	 * new value with a ParameterStatus message once the reload reaches its
+	 * backend. PQconsumeInput() only reads bytes; PQisBusy() forces the
+	 * parsing that applies the ParameterStatus.
+	 */
+	for (i = 0; i < 1000; i++)
+	{
+		if (!PQconsumeInput(conn))
+			pg_fatal("PQconsumeInput failed: %s", PQerrorMessage(conn));
+		(void) PQisBusy(conn);
+
+		val = PQparameterStatus(conn, "IntervalStyle");
+		if (val && strcmp(val, "iso_8601") == 0)
+			break;
+
+		pg_usleep(10000);		/* 10ms */
+	}
+
+	val = PQparameterStatus(conn, "IntervalStyle");
+	if (!val || strcmp(val, "iso_8601") != 0)
+		pg_fatal("IntervalStyle not reported as iso_8601 for idle connection after reload");
+
+	/* Restore the previous configuration for any later tests on this server. */
+	res = PQexec(otherConn, "ALTER SYSTEM RESET intervalstyle");
+	if (PQresultStatus(res) != PGRES_COMMAND_OK)
+		pg_fatal("ALTER SYSTEM RESET failed: %s", PQerrorMessage(otherConn));
+	PQclear(res);
+	res = PQexec(otherConn, "SELECT pg_reload_conf()");
+	if (PQresultStatus(res) != PGRES_TUPLES_OK)
+		pg_fatal("pg_reload_conf() failed: %s", PQerrorMessage(otherConn));
+	PQclear(res);
+
+	PQfinish(otherConn);
+
+	fprintf(stderr, "ok\n");
+}
 
 static void
 usage(const char *progname)
@@ -2118,6 +2193,7 @@ print_test_list(void)
 {
 	printf("cancel\n");
 	printf("disallowed_in_pipeline\n");
+	printf("idle_config_report\n");
 	printf("multi_pipelines\n");
 	printf("nosync\n");
 	printf("pipeline_abort\n");
@@ -2225,6 +2301,8 @@ main(int argc, char **argv)
 		test_cancel(conn);
 	else if (strcmp(testname, "disallowed_in_pipeline") == 0)
 		test_disallowed_in_pipeline(conn);
+	else if (strcmp(testname, "idle_config_report") == 0)
+		test_idle_config_report(conn);
 	else if (strcmp(testname, "multi_pipelines") == 0)
 		test_multi_pipelines(conn);
 	else if (strcmp(testname, "nosync") == 0)


### PR DESCRIPTION
- **Report GUC_REPORT changes to idle clients right away**
- **Apply configuration reloads while a backend waits for a command**
